### PR TITLE
Fix the pytz example in the docs index.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ Here is the world without a flux capacitor at your side.::
     utc = timezone(UTC)
     est = timezone(EST)
     d = utc.localize(d)
-    d = est.normalize(EST)
+    d = est.normalize(d)
     return d
 
 Now lets warm up the `delorean`::


### PR DESCRIPTION
The main page of the docs currently have a pytz example that includes the
following erroneous line:
d = est.normalize(EST)

Flux capacitor or no, that's going to stop you well short of 88mph.
