### PR TITLE
Adds a copy() method for returning a copy of the Delorean object with a new timezone

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -191,6 +191,9 @@ class Delorean(object):
             return self._dt == other._dt and self._tz == other._tz
         return False
 
+    def __ne__(self, other):
+        return not self == other
+
     def __getattr__(self, name):
         """
         Implement __getattr__ to call `shift_date` function when function

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -332,8 +332,12 @@ class DeloreanTests(TestCase):
         self.assertEqual(self.do, do)
 
     def test_not_equal(self):
-        d = delorean.Delorean()
-        self.assertNotEqual(d, None)
+        d1 = delorean.Delorean()
+        self.assertNotEqual(d1, None)
+
+        # makes sure the overloaded comparisons work properly
+        d2 = deepcopy(d1)
+        self.assertFalse(d1 != d2, 'Overloaded __ne__ is not correct')
 
     def test_equal(self):
         d1 = delorean.Delorean()


### PR DESCRIPTION
shift() currently mutates the original Delorean object, so this is just a simple way to get a copy of the current object with an optional new timezone.
