### PR TITLE
Make __eq__ a safe operation

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -188,7 +188,12 @@ class Delorean(object):
 
     def __eq__(self, other):
         # test this.
-        return self._dt == other._dt and self._tz == other._tz
+        try:
+            result = self._dt == other._dt and self._tz == other._tz
+        except AttributeError:
+            result = False
+
+        return result
 
     def __getattr__(self, name):
         """


### PR DESCRIPTION
We don't want to throw and Attribute error when you do
delorean_obj == nondelorean_obj, this should just say they they are not equal.
