### PR TITLE
Make __eq__ a safe operation

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -187,8 +187,9 @@ class Delorean(object):
         return 'Delorean(datetime=%s, timezone=%s)' % (self._dt, self._tz)
 
     def __eq__(self, other):
-        # test this.
-        return self._dt == other._dt and self._tz == other._tz
+        if isinstance(other, Delorean):
+            return self._dt == other._dt and self._tz == other._tz
+        return False
 
     def __getattr__(self, name):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,7 @@ Testing for Delorean
 
 from unittest import TestCase, main
 from datetime import datetime, date, timedelta
+from copy import deepcopy
 
 from pytz import timezone
 import delorean
@@ -329,6 +330,15 @@ class DeloreanTests(TestCase):
     def test_epoch_creation(self):
         do = delorean.epoch(1357187474.148546)
         self.assertEqual(self.do, do)
+
+    def test_not_equal(self):
+        d = delorean.Delorean()
+        self.assertNotEqual(d, None)
+
+    def test_equal(self):
+        d1 = delorean.Delorean()
+        d2 = deepcopy(d1)
+        self.assertEqual(d1, d2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We don't want to throw and Attribute error when you do
delorean_obj == nondelorean_obj, this should just say they they are not
equal. So we ensure that it is a Delorean object instead

Added some tests. 
