### PR TITLE
Fix for overloaded __ne__ operator

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -191,6 +191,9 @@ class Delorean(object):
             return self._dt == other._dt and self._tz == other._tz
         return False
 
+    def __ne__(self, other):
+        return not self == other
+
     def __getattr__(self, name):
         """
         Implement __getattr__ to call `shift_date` function when function

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -339,7 +339,7 @@ class DeloreanTests(TestCase):
         d1 = delorean.Delorean()
         d2 = deepcopy(d1)
         self.assertEqual(d1, d2)
-
+        self.assertFalse(d1 != d2, 'Overloaded __ne__ is not correct')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Currently if there are two delorean objects that are identical:

``` python
>>> d1 = Delorean(datetime(2013, 1, 1), 'UTC')
>>> d2 = Delorean(datetime(2013, 1, 1), 'UTC')
```

They will evaluate as both equal to and not equal to each other at the same time:

``` python
>>> d1 == d2 and d1 != d2
True
>>> # great scott!
```
