### PR TITLE
Remove extra 'precedence' in quickstart docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -169,7 +169,7 @@ Ambiguous cases
 
 There might be cases where the string passed to parse is a bit ambiguous for example. In the case where `2013-05-06` is passed is this May 6th, 2013 or is June 5th, 2013?
 
-precedence`Delorean` makes the assumptions that ``dayfirst=True`` and ``yearfirst=True`` this will lead to the following precedence.
+`Delorean` makes the assumptions that ``dayfirst=True`` and ``yearfirst=True`` this will lead to the following precedence.
 
 
     If dayfirst is True and yearfirst is True:


### PR DESCRIPTION
This commit fixes #52