### PR TITLE
Delorean objects are equal if they are UTC equal

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -180,12 +180,8 @@ class Delorean(object):
         self._dt = datetime
 
         if not is_datetime_naive(datetime):
-            # if already localized find the zone
-            # once zone is found set _tz and the localized datetime
-            # to _dt
             naive = False
-            zone = datetime.tzinfo.tzname(None)
-            self._tz = zone
+            self._tz = datetime.tzinfo.tzname(None)
             self._dt = datetime
 
         if naive:
@@ -209,7 +205,7 @@ class Delorean(object):
 
     def __eq__(self, other):
         if isinstance(other, Delorean):
-            return self._dt == other._dt and self._tz == other._tz
+            return self.epoch() == other.epoch()
         return False
 
     def __lt__(self, other):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -485,6 +485,10 @@ class DeloreanTests(TestCase):
         self.assertEqual(d1, d2)
         self.assertFalse(d1 != d2, 'Overloaded __ne__ is not correct')
 
+        d1 = delorean.Delorean(datetime(2015, 1, 1), timezone='US/Pacific')
+        d2 = delorean.Delorean(datetime(2015, 1, 1, 8), timezone='UTC')
+        self.assertEqual(d1, d2)
+
     def test_timezone_delorean_to_datetime_to_delorean_utc(self):
         d1 = delorean.Delorean()
         d2 = delorean.Delorean(d1.datetime)


### PR DESCRIPTION
Testing equality on Delorean objects should go beyond checking to see if they represent the same time in the same timezone.  It should check to see if the time represented by each object is equivalent in UTC time.

Fixes issue #61 