### PR TITLE
Adds support for fractional units to next_/last_ week/day/hour/minute…

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -196,7 +196,7 @@ class Delorean(object):
                     self._tzinfo = self._dt.tzinfo
                 else:
                     #TODO(mlew, 2015-08-09):
-                    # Should we really throw an error here, or should this 
+                    # Should we really throw an error here, or should this
                     # default to UTC?)
                     raise DeloreanInvalidTimezone('Provide a valid timezone')
             else:
@@ -292,7 +292,11 @@ class Delorean(object):
 
         num_shifts = 1
         if len(args) > 0:
-            num_shifts = int(args[0])
+            # dateutils.relativedelta supports fractional amounts for these units:
+            if unit in ['week', 'day', 'hour', 'minute', 'second']:
+                num_shifts = float(args[0])
+            else:
+                num_shifts = int(args[0])
 
         if unit in ['monday', 'tuesday', 'wednesday', 'thursday', 'friday',
                     'saturday', 'sunday']:


### PR DESCRIPTION
…/second.

Re: issue #75, this appears to be related to https://github.com/dateutil/dateutil/issues/40 + https://github.com/myusuf3/delorean/blob/master/delorean/dates.py#L295. It looks like some sort of official relativedelta float-support for fractional years/months might be coming in the 2.5.0 release of dateutils. In the meantime, floats do work with relativedelta for weeks down to microseconds. 

This patch adds support for those. If you think this is a worthwhile idea, I'm happy to write some tests for it.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/myusuf3/delorean/77)

<!-- Reviewable:end -->
