### PR TITLE
Test on and declare support for Python 3.7-3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.6-dev"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
+  - "3.9"
   - "pypy"
   - "pypy3"
 install: pip install -r requirements.txt &&  python setup.py develop

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     install_requires=dependencies,
     test_suite='tests.test_data',
     long_description=open('README.rst').read(),
+    python_requires='>=2.6, !=3.0.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Also add `python_requires` to help pip install the right version of the library for the user.

---

By the way: Python 2.6, 2.7, 3.1, 3.2, 3.3, 3.4 and 3.5 are now EOL, maybe drop them? Especially some are ancient and not tested or testable any more on CI.

https://devguide.python.org/devcycle/#end-of-life-branches