### PR TITLE
docs: Fix a few typos

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -335,7 +335,7 @@ class Delorean(object):
 
     def truncate(self, s):
         """
-        Truncate the delorian object to the nearest s
+        Truncate the delorean object to the nearest s
         (second, minute, hour, day, month, year)
 
         This is a destructive method, modifies the internal datetime
@@ -426,7 +426,7 @@ class Delorean(object):
     @property
     def start_of_day(self):
         """
-        Returns the start of the day for datetime assoicated
+        Returns the start of the day for datetime associated
         with the Delorean object, modifying the Delorean object.
 
         .. testsetup::
@@ -447,7 +447,7 @@ class Delorean(object):
     def end_of_day(self):
         """
         Returns the end of the day for the datetime
-        assocaited with the Delorean object, modifying the Delorean object.
+        associated with the Delorean object, modifying the Delorean object.
 
         .. testsetup::
 

--- a/delorean/interface.py
+++ b/delorean/interface.py
@@ -143,7 +143,7 @@ def stops(freq, interval=1, count=None, wkst=None, bysetpos=None,
           bysecond=None, timezone='UTC', start=None, stop=None):
     """
     This will create a list of delorean objects the apply to
-    setting possed in.
+    setting posed in.
     """
     # check to see if datetimees passed in are naive if so process them
     # with given timezone.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@ This software can be installed in multiple ways. The ways that are recommended a
 
 Obtaining the Source
 ^^^^^^^^^^^^^^^^^^^^
-This is a library targeted specifcally to developers so you will most likely want to get your hands on the source. It can be obtained as follows.::
+This is a library targeted specifically to developers so you will most likely want to get your hands on the source. It can be obtained as follows.::
 
     $ git clone git://github.com/myusuf3/delorean.git
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,6 +1,6 @@
 Usage
 =====
-`Delorean` aims to provide you with convient ways to get significant dates and times and easy ways to move dates from state to state.
+`Delorean` aims to provide you with convenient ways to get significant dates and times and easy ways to move dates from state to state.
 
 In order to get the most of the documentation we will define some terminology.
 


### PR DESCRIPTION
There are small typos in:
- delorean/dates.py
- delorean/interface.py
- docs/install.rst
- docs/quickstart.rst

Fixes:
- Should read `specifically` rather than `specifcally`.
- Should read `posed` rather than `possed`.
- Should read `delorean` rather than `delorian`.
- Should read `convenient` rather than `convient`.
- Should read `associated` rather than `assoicated`.
- Should read `associated` rather than `assocaited`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md