### PR TITLE
Add Sphinx documentation build to CI and update documentation config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,3 +14,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync
       - run: uv run pytest
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+      - run: uv run --group docs sphinx-build -b doctest docs docs/_build/doctest
+      - run: uv run --group docs sphinx-build -b html -W docs docs/_build/html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Here is the world without a flux capacitor at your side.::
     est = pytz.timezone('US/Eastern')
     d = datetime.now(pytz.utc)
     d = est.normalize(d.astimezone(est))
-    return d
+    d
 
 Now lets warm up the `delorean`::
 
@@ -51,7 +51,7 @@ Now lets warm up the `delorean`::
 
     d = Delorean()
     d = d.shift('US/Eastern')
-    return d
+    d
 
 Look at you looking all fly. This was just a test drive checkout out what else
 `delorean` can help with below.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -37,7 +37,7 @@ Now that you have successfully shifted the timezone you can easily return a loca
 ::
 
     >>> d.datetime
-    datetime.datetime(2013, 1, 12, 01, 10, 38, 102223, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+    datetime.datetime(2013, 1, 12, 1, 10, 38, 102223, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
     >>> d.date
     datetime.date(2013, 1, 12)
 
@@ -45,7 +45,7 @@ For the purists out there you can do things like so.
 ::
 
     >>> d.naive
-    datetime.datetime(2013, 1, 12, 1, 10, 38, 102223)
+    datetime.datetime(2013, 1, 12, 6, 10, 38, 102223)
     >>> d.epoch
     1357971038.102223
 
@@ -53,7 +53,7 @@ You can also create Delorean object using unix timestamps.
 
 ::
 
-    from delorean import epoch
+    >>> from delorean import epoch
     >>> epoch(1357971038.102223).shift("US/Eastern")
     Delorean(datetime=datetime.datetime(2013, 1, 12, 1, 10, 38, 102223), timezone='US/Eastern')
 
@@ -168,7 +168,7 @@ Often we dont care how many milliseconds or even seconds that are present in our
 Though it might seem obvious `delorean` also provides truncation to the month and year levels as well.
 ::
 
-    >>> d = Delorean(datetime=datetime(2012, 5, 15, 03, 50, 00, 555555), timezone="US/Eastern")
+    >>> d = Delorean(datetime=datetime(2012, 5, 15, 3, 50, 0, 555555), timezone="US/Eastern")
     >>> d
     Delorean(datetime=datetime.datetime(2012, 5, 15, 3, 50, 0, 555555), timezone='US/Eastern')
     >>> d.truncate('month')
@@ -260,8 +260,8 @@ Now that you can do this you can also specify ``timezones`` as well ``start`` an
     >>> import delorean
     >>> from delorean import stops
     >>> from datetime import datetime
-    >>> d1 = datetime(2012, 5, 06)
-    >>> d2 = datetime(2013, 5, 06)
+    >>> d1 = datetime(2012, 5, 6)
+    >>> d2 = datetime(2013, 5, 6)
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,25 @@ name = "delorean"
 version = "1.0.1"
 description = "library for manipulating datetimes with ease and clarity"
 readme = "README.rst"
-license = { text = "MIT license" }
+license = "MIT"
+license-files = ["LICENSE.txt"]
 authors = [{ name = "Mahdi Yusuf", email = "yusuf.mahdi@gmail.com" }]
 requires-python = ">=3.9"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
     "babel>=2.10.3",
     "humanize>=4.2.2",


### PR DESCRIPTION
## Summary
This pull request enhances the project’s documentation setup by adding Sphinx documentation builds and doctests to the GitHub Actions CI workflow. It also updates Sphinx and project configuration files for consistency, improves Python version support, and refines code documentation examples and metadata.

## Changes Made
- Add a new `docs` job to the CI workflow to build docs and run doctests using Sphinx and uv.
- Update `Makefile` to use `uv run --group docs sphinx-build` for Sphinx commands to ensure environment isolation.
- Modernize Sphinx config to fetch version from `importlib.metadata` and update intersphinx mapping.
- Fix and clarify doctest examples and narrative in the main documentation and quickstart guide.
- Add a changelog file and ensure it is included in documentation.
- Update project metadata in `pyproject.toml`:
  - Add more precise license and classifier fields.
  - Add optional Sphinx requirement for docs.
  - Expand supported Python versions to include 3.14 and adjust version markers.
- Update `uv.lock` to pin and record new Sphinx and doc-related dependencies.

## Files Modified
- **.github/workflows/tests.yml**: Adds documentation build and doctest job to the CI workflow.
- **Makefile**: Updates the docs build command to use uv and Sphinx directly.
- **delorean/dates.py**: Minor corrections to docstring examples for doctest compliance.
- **docs/changelog.rst**: Adds new changelog stub for documentation inclusion.
- **docs/conf.py**: Updates Sphinx configuration (versioning, intersphinx mapping, doc include).
- **docs/index.rst**: Refines code/output examples for consistency in main docs.
- **docs/quickstart.rst**: Updates code examples for clarity and correctness.
- **pyproject.toml**: Enhances project metadata, classifiers, and metadata for docs.
- **uv.lock**: Records updated and added dependencies necessary for documentation builds and Python version compatibility.

## Important Notes
- The new CI docs job will ensure documentation and examples remain correct as part of PR validation.
- This PR requires Python 3.10 or greater to build docs, with 3.12+ preferred for full support.
- Sphinx and necessary doc dependencies are now formally specified; please ensure local development environments are updated.
- No breaking changes to the package runtime, but contributors should use the new doc build workflow (`make -C docs clean doctest html`) or via the updated CI commands.
- Downstream builds or releases should also ensure the changelog is kept up to date in `docs/changelog.rst`.