### PR TITLE
Fix: raise AttributeError on invalid shift name instead of returning it

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -297,7 +297,7 @@ class Delorean(object):
             func_parts[0] not in self._VALID_SHIFT_DIRECTIONS
             or func_parts[1] not in self._VALID_SHIFT_UNITS
         ):
-            return AttributeError
+            raise AttributeError
 
         # dispatch our function
         func = partial(self._shift_date, func_parts[0], func_parts[1])

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -624,6 +624,15 @@ class DeloreanTests(unittest.TestCase):
             delorean.DeloreanInvalidTimezone, self.do.shift, "US/Westerrn"
         )
 
+    def test_invalid_shift_unit_raises(self):
+        self.assertRaises(AttributeError, getattr, self.do, "next_bogus")
+
+    def test_invalid_shift_direction_raises(self):
+        self.assertRaises(AttributeError, getattr, self.do, "sideways_day")
+
+    def test_invalid_shift_name_is_not_reported_by_hasattr(self):
+        self.assertFalse(hasattr(self.do, "next_bogus"))
+
     def test_datetime_localization(self):
         dt1 = self.do.datetime
         dt2 = delorean.Delorean(dt1).datetime


### PR DESCRIPTION
`Delorean.__getattr__` used `return AttributeError` where it meant `raise AttributeError`, so an invalid shift name handed back the exception class instead of raising.

Effect before this change:

```python
>>> d = Delorean()
>>> d.next_bogus
<class 'AttributeError'>
>>> hasattr(d, 'next_bogus')
True
```

`hasattr` reporting `True` for a method that does not exist is the most damaging part, and calling the result constructed an `AttributeError` instance rather than raising, so the failure was silent. The adjacent check for a wrong number of name parts already used `raise`, so this was a one-word typo.

Adds three tests covering an invalid unit (`next_bogus`), an invalid direction (`sideways_day`), and that `hasattr` now reports `False`. All three fail before the fix and pass after.

Note this is technically a behaviour change for anyone relying on the truthy return value, though that seems implausible.

Stacked on #130 so the reformatted `dates.py` does not conflict.