### PR TITLE
Document and test daylight saving resolution rules

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -154,6 +154,54 @@ Last Tuesday? Two Tuesdays ago at midnight? No problem.
     datetime.datetime(2013, 1, 8, 0, 0, tzinfo=<UTC>)
 
 
+Daylight Saving Transitions
+"""""""""""""""""""""""""""
+
+Shifting moves the wall clock and then re-localizes the result, so crossing a
+daylight saving boundary keeps the local time you asked for and updates the
+offset to match. Below, 07:00 stays 07:00 and the timezone changes from EST to
+EDT, which means the shift advanced 23 actual hours rather than 24.
+
+.. doctest::
+
+    >>> from pytz import timezone
+    >>> eastern = timezone("US/Eastern")
+    >>> d = Delorean(eastern.localize(datetime(2013, 3, 9, 7, 0)))
+    >>> d.next_day().datetime
+    datetime.datetime(2013, 3, 10, 7, 0, tzinfo=<DstTzInfo 'US/Eastern' EDT-1 day, 20:00:00 DST>)
+
+Two kinds of local time need a tie-breaking rule, and `delorean` resolves both
+of them to **standard** time.
+
+A local time inside the spring-forward gap never happens. On 10 March 2013 the
+Eastern clocks jumped straight from 02:00 EST to 03:00 EDT, so 02:30 has no
+local reading at all. Shifting into it returns 02:30 EST, which is the instant
+07:30 UTC.
+
+.. doctest::
+
+    >>> d = Delorean(eastern.localize(datetime(2013, 3, 9, 2, 30)))
+    >>> d.next_day().datetime
+    datetime.datetime(2013, 3, 10, 2, 30, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+
+A local time inside the autumn fall-back happens twice. On 3 November 2013,
+01:30 occurs once as EDT and then again an hour later as EST. Shifting into it
+returns the second, post-transition occurrence.
+
+.. doctest::
+
+    >>> d = Delorean(eastern.localize(datetime(2013, 11, 2, 1, 30)))
+    >>> d.next_day().datetime
+    datetime.datetime(2013, 11, 3, 1, 30, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+
+.. note::
+
+    This rule is not specific to shifting. It applies wherever `delorean`
+    localizes a naive datetime, because it comes from `pytz`'s ``is_dst=False``
+    default. Pass an already-localized datetime if you need to choose the other
+    side of a transition yourself.
+
+
 Replace Parts
 ^^^^^^^^^^^^^
 Using the `replace` method on `Delorean` objects, we can replace the `hour`, `minute`, `second`, `year` etc

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -633,6 +633,42 @@ class DeloreanTests(unittest.TestCase):
     def test_invalid_shift_name_is_not_reported_by_hasattr(self):
         self.assertFalse(hasattr(self.do, "next_bogus"))
 
+    def test_shift_across_dst_keeps_wall_clock(self):
+        eastern = pytz.timezone("US/Eastern")
+        do = delorean.Delorean(eastern.localize(datetime(2013, 3, 9, 7, 0)))
+
+        shifted = do.next_day().datetime
+        self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-03-10 07:00")
+        self.assertEqual(shifted.tzname(), "EDT")
+
+    def test_shift_into_nonexistent_local_time_resolves_to_standard(self):
+        # Eastern clocks jump 02:00 EST -> 03:00 EDT on 2013-03-10, so 02:30
+        # has no local reading at all that day.
+        eastern = pytz.timezone("US/Eastern")
+        do = delorean.Delorean(eastern.localize(datetime(2013, 3, 9, 2, 30)))
+
+        shifted = do.next_day().datetime
+        self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-03-10 02:30")
+        self.assertEqual(shifted.tzname(), "EST")
+        self.assertEqual(shifted.astimezone(pytz.utc).strftime("%H:%M"), "07:30")
+
+    def test_shift_into_ambiguous_local_time_resolves_to_standard(self):
+        # 01:30 happens twice on 2013-11-03, first as EDT and then as EST.
+        eastern = pytz.timezone("US/Eastern")
+        do = delorean.Delorean(eastern.localize(datetime(2013, 11, 2, 1, 30)))
+
+        shifted = do.next_day().datetime
+        self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-11-03 01:30")
+        self.assertEqual(shifted.tzname(), "EST")
+
+    def test_localize_nonexistent_local_time_resolves_to_standard(self):
+        dt = delorean.localize(datetime(2013, 3, 10, 2, 30), "US/Eastern")
+        self.assertEqual(dt.tzname(), "EST")
+
+    def test_localize_ambiguous_local_time_resolves_to_standard(self):
+        dt = delorean.localize(datetime(2013, 11, 3, 1, 30), "US/Eastern")
+        self.assertEqual(dt.tzname(), "EST")
+
     def test_datetime_localization(self):
         dt1 = self.do.datetime
         dt2 = delorean.Delorean(dt1).datetime


### PR DESCRIPTION
Follows the finding that delorean's DST tie-breaking rule was correct and deterministic but undocumented. Nothing in the docs said how a shift resolves a local time that either does not exist or happens twice.

## Documentation

Adds a "Daylight Saving Transitions" subsection to the quickstart with three working examples:

- A normal crossing keeps the wall clock and updates the offset, so 07:00 EST becomes 07:00 EDT. Worth stating plainly that this advances 23 real hours, not 24.
- A spring-forward gap time resolves to standard time: shifting into 02:30 on 2013-03-10, which never occurs locally, returns 02:30 EST (the instant 07:30 UTC).
- An autumn fall-back ambiguity resolves to standard time as well, returning the second, post-transition occurrence of 01:30 on 2013-11-03.

A note explains this is not shift-specific. It comes from `pytz`'s `is_dst=False` default and applies wherever delorean localizes a naive datetime.

All three examples are real doctests, so the documented rule cannot drift. Quickstart goes from 61 to 71 executed examples; the suite as a whole from 95 to 103.

## Tests

Five tests in `tests/delorean_tests.py` codify the behaviour, covering the shift path and the `localize()` path directly:

- `test_shift_across_dst_keeps_wall_clock`
- `test_shift_into_nonexistent_local_time_resolves_to_standard` (also asserts the resulting UTC instant)
- `test_shift_into_ambiguous_local_time_resolves_to_standard`
- `test_localize_nonexistent_local_time_resolves_to_standard`
- `test_localize_ambiguous_local_time_resolves_to_standard`

Unit tests go from 93 to 98.

I verified these are not vacuous by mutating `localize()` to call `tz.normalize()` afterwards, which moves a gap time from 02:30 EST to 03:30 EDT. Two tests failed as intended, then I reverted.

## Why this matters beyond documentation

`zoneinfo` resolves gaps and ambiguity via the `fold` attribute under different rules, so a future migration off pytz would silently change these answers. These tests now make that change visible instead of surprising.

Stacked on #131.