### PR TITLE
Land the AttributeError fix and DST docs/tests that were stranded on lint-black

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -297,7 +297,7 @@ class Delorean(object):
             func_parts[0] not in self._VALID_SHIFT_DIRECTIONS
             or func_parts[1] not in self._VALID_SHIFT_UNITS
         ):
-            return AttributeError
+            raise AttributeError
 
         # dispatch our function
         func = partial(self._shift_date, func_parts[0], func_parts[1])

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -154,6 +154,54 @@ Last Tuesday? Two Tuesdays ago at midnight? No problem.
     datetime.datetime(2013, 1, 8, 0, 0, tzinfo=<UTC>)
 
 
+Daylight Saving Transitions
+"""""""""""""""""""""""""""
+
+Shifting moves the wall clock and then re-localizes the result, so crossing a
+daylight saving boundary keeps the local time you asked for and updates the
+offset to match. Below, 07:00 stays 07:00 and the timezone changes from EST to
+EDT, which means the shift advanced 23 actual hours rather than 24.
+
+.. doctest::
+
+    >>> from pytz import timezone
+    >>> eastern = timezone("US/Eastern")
+    >>> d = Delorean(eastern.localize(datetime(2013, 3, 9, 7, 0)))
+    >>> d.next_day().datetime
+    datetime.datetime(2013, 3, 10, 7, 0, tzinfo=<DstTzInfo 'US/Eastern' EDT-1 day, 20:00:00 DST>)
+
+Two kinds of local time need a tie-breaking rule, and `delorean` resolves both
+of them to **standard** time.
+
+A local time inside the spring-forward gap never happens. On 10 March 2013 the
+Eastern clocks jumped straight from 02:00 EST to 03:00 EDT, so 02:30 has no
+local reading at all. Shifting into it returns 02:30 EST, which is the instant
+07:30 UTC.
+
+.. doctest::
+
+    >>> d = Delorean(eastern.localize(datetime(2013, 3, 9, 2, 30)))
+    >>> d.next_day().datetime
+    datetime.datetime(2013, 3, 10, 2, 30, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+
+A local time inside the autumn fall-back happens twice. On 3 November 2013,
+01:30 occurs once as EDT and then again an hour later as EST. Shifting into it
+returns the second, post-transition occurrence.
+
+.. doctest::
+
+    >>> d = Delorean(eastern.localize(datetime(2013, 11, 2, 1, 30)))
+    >>> d.next_day().datetime
+    datetime.datetime(2013, 11, 3, 1, 30, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+
+.. note::
+
+    This rule is not specific to shifting. It applies wherever `delorean`
+    localizes a naive datetime, because it comes from `pytz`'s ``is_dst=False``
+    default. Pass an already-localized datetime if you need to choose the other
+    side of a transition yourself.
+
+
 Replace Parts
 ^^^^^^^^^^^^^
 Using the `replace` method on `Delorean` objects, we can replace the `hour`, `minute`, `second`, `year` etc

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -633,6 +633,42 @@ class DeloreanTests(unittest.TestCase):
     def test_invalid_shift_name_is_not_reported_by_hasattr(self):
         self.assertFalse(hasattr(self.do, "next_bogus"))
 
+    def test_shift_across_dst_keeps_wall_clock(self):
+        eastern = pytz.timezone("US/Eastern")
+        do = delorean.Delorean(eastern.localize(datetime(2013, 3, 9, 7, 0)))
+
+        shifted = do.next_day().datetime
+        self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-03-10 07:00")
+        self.assertEqual(shifted.tzname(), "EDT")
+
+    def test_shift_into_nonexistent_local_time_resolves_to_standard(self):
+        # Eastern clocks jump 02:00 EST -> 03:00 EDT on 2013-03-10, so 02:30
+        # has no local reading at all that day.
+        eastern = pytz.timezone("US/Eastern")
+        do = delorean.Delorean(eastern.localize(datetime(2013, 3, 9, 2, 30)))
+
+        shifted = do.next_day().datetime
+        self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-03-10 02:30")
+        self.assertEqual(shifted.tzname(), "EST")
+        self.assertEqual(shifted.astimezone(pytz.utc).strftime("%H:%M"), "07:30")
+
+    def test_shift_into_ambiguous_local_time_resolves_to_standard(self):
+        # 01:30 happens twice on 2013-11-03, first as EDT and then as EST.
+        eastern = pytz.timezone("US/Eastern")
+        do = delorean.Delorean(eastern.localize(datetime(2013, 11, 2, 1, 30)))
+
+        shifted = do.next_day().datetime
+        self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-11-03 01:30")
+        self.assertEqual(shifted.tzname(), "EST")
+
+    def test_localize_nonexistent_local_time_resolves_to_standard(self):
+        dt = delorean.localize(datetime(2013, 3, 10, 2, 30), "US/Eastern")
+        self.assertEqual(dt.tzname(), "EST")
+
+    def test_localize_ambiguous_local_time_resolves_to_standard(self):
+        dt = delorean.localize(datetime(2013, 11, 3, 1, 30), "US/Eastern")
+        self.assertEqual(dt.tzname(), "EST")
+
     def test_datetime_localization(self):
         dt1 = self.do.datetime
         dt2 = delorean.Delorean(dt1).datetime

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -624,6 +624,15 @@ class DeloreanTests(unittest.TestCase):
             delorean.DeloreanInvalidTimezone, self.do.shift, "US/Westerrn"
         )
 
+    def test_invalid_shift_unit_raises(self):
+        self.assertRaises(AttributeError, getattr, self.do, "next_bogus")
+
+    def test_invalid_shift_direction_raises(self):
+        self.assertRaises(AttributeError, getattr, self.do, "sideways_day")
+
+    def test_invalid_shift_name_is_not_reported_by_hasattr(self):
+        self.assertFalse(hasattr(self.do, "next_bogus"))
+
     def test_datetime_localization(self):
         dt1 = self.do.datetime
         dt2 = delorean.Delorean(dt1).datetime


### PR DESCRIPTION
Recovers work from #131 and #132 that never reached master.

## What happened

Both were stacked with `lint-black` as their base. #130 merged `lint-black` into master first, and #131 and #132 were merged into `lint-black` afterwards, so their commits landed on a branch that was no longer flowing anywhere. Master ended up with the black/ruff setup from #130 but not the two changes built on top of it. This is my fault: I advised merging the stack in the order #130, #131, #132, which is backwards for these bases.

Confirmed by inspection: `origin/master` still had `return AttributeError` at dates.py:300, and neither the DST tests nor the docs section were present.

## What this contains

The four stranded commits, nothing new:

- `fix(dates): raise error on invalid shift instead of returning exception` — `Delorean.__getattr__` returned the `AttributeError` class instead of raising it, so `hasattr(d, 'next_bogus')` wrongly reported `True`. Plus three tests.
- `docs: add daylight saving transitions section to quickstart guide` — documents how a shift resolves a local time that either never happens (spring-forward gap) or happens twice (autumn fall-back), both resolving to standard time via pytz's `is_dst=False` default. Three working doctests plus five tests covering the shift and `localize()` paths.

## Verified on this branch

- 98 unit tests pass
- 103 doctests pass
- `black --check` and `ruff check` both clean

## Note for future stacks

With PR bases chained like this, merge from the top of the stack down, or retarget each PR to master as its parent merges. Merging the base first strands everything above it.