### PR TITLE
Remove mock as a development dependency and use unittest.mock [113]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ Homepage = "https://github.com/myusuf3/delorean"
 [dependency-groups]
 dev = [
     "black",
-    "mock",
     "pytest",
     "ruff",
 ]

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -8,8 +8,8 @@ Testing for Delorean
 import unittest
 from copy import deepcopy
 from datetime import date, datetime, timedelta, timezone, tzinfo
+from unittest import mock
 
-import mock
 import pytz
 from dateutil.parser import UnknownTimezoneWarning
 from dateutil.tz import tzlocal, tzoffset

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
-    { name = "mock" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -223,7 +222,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black" },
-    { name = "mock" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -397,15 +395,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "mock"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/8c/14c2ae915e5f9dca5a22edd68b35be94400719ccfa068a03e0fb63d0f6f6/mock-5.2.0.tar.gz", hash = "sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0", size = 92796, upload-time = "2025-03-03T12:31:42.911Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/d9/617e6af809bf3a1d468e0d58c3997b1dc219a9a9202e650d30c2fc85d481/mock-5.2.0-py3-none-any.whl", hash = "sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f", size = 31617, upload-time = "2025-03-03T12:31:41.518Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Removes the external `mock` library from the development dependencies and switches the test suite to the standard library's `unittest.mock`.

## Changes
- `tests/delorean_tests.py`: `import mock` becomes `from unittest import mock`. That is the whole code change; all 24 `mock.patch` and `.return_value` usages are unchanged because the API is identical.
- `pyproject.toml`: `mock` removed from the dev dependency group.
- `uv.lock`: re-locked, dropping the package.

## Verified
- `mock` is genuinely gone, not merely unlisted: `uv run python -c "import mock"` now raises `ModuleNotFoundError`, so the tests cannot silently still be using it.
- 98 tests pass, including the 8 that actually exercise mocking (`@mock.patch` on `datetime_timezone`, `get_localzone` and `Delorean.now`).
- Passes on both ends of the supported range, 3.10 and 3.14.
- 103 doctests pass; `html -W`, black and ruff all clean.

## Notes
`unittest.mock` has been in the standard library since 3.3 and the project requires 3.10+, so there is no fallback or conditional import needed. Ruff's UP026 rule flags this pattern too, so enabling the `UP` family later (see the stricter-rules follow-up) will no longer trip on it.

Fixes #113