### PR TITLE
Add timestamp naming, return Delorean from boundary properties, add month/year boundaries

### DIFF
--- a/delorean/__init__.py
+++ b/delorean/__init__.py
@@ -33,6 +33,7 @@ from delorean.exceptions import DeloreanInvalidDatetime, DeloreanInvalidTimezone
 from delorean.interface import (
     epoch,
     flux,
+    from_timestamp,
     now,
     parse,
     range_daily,

--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -516,10 +516,36 @@ class Delorean(object):
         return self
 
     @property
+    def timestamp(self):
+        """
+        Returns the total seconds since the Unix epoch associated with
+        the Delorean object.
+
+        .. testsetup::
+
+            from datetime import datetime
+            from delorean import Delorean
+
+        .. doctest::
+
+            >>> d = Delorean(datetime(2015, 1, 1), timezone='US/Pacific')
+            >>> d.timestamp
+            1420099200.0
+
+        """
+        epoch_sec = datetime.fromtimestamp(0, timezone.utc)
+        now_sec = pytz.utc.normalize(self._dt)
+        delta_sec = now_sec - epoch_sec
+        return get_total_second(delta_sec)
+
+    @property
     def epoch(self):
         """
-        Returns the total seconds since epoch associated with
-        the Delorean object.
+        Alias of :attr:`timestamp`, kept for backwards compatibility.
+
+        The value is seconds since the Unix epoch, so `timestamp` is the
+        more accurate name; the epoch itself is the fixed point the count
+        starts from.
 
         .. testsetup::
 
@@ -533,10 +559,7 @@ class Delorean(object):
             1420099200.0
 
         """
-        epoch_sec = datetime.fromtimestamp(0, timezone.utc)
-        now_sec = pytz.utc.normalize(self._dt)
-        delta_sec = now_sec - epoch_sec
-        return get_total_second(delta_sec)
+        return self.timestamp
 
     @property
     def date(self):

--- a/delorean/interface.py
+++ b/delorean/interface.py
@@ -203,9 +203,34 @@ def stops(
         yield d
 
 
-def epoch(s):
+def from_timestamp(s):
+    """
+    Return a `Delorean` object for the given seconds since the Unix epoch.
+
+    .. testsetup::
+
+        from delorean import from_timestamp
+
+    .. doctest::
+
+        >>> from_timestamp(1420099200.0)
+        Delorean(datetime=datetime.datetime(2015, 1, 1, 8, 0), timezone='UTC')
+
+    """
     dt = datetime.fromtimestamp(s, timezone.utc).replace(tzinfo=None)
     return Delorean(datetime=dt, timezone="UTC")
+
+
+def epoch(s):
+    """
+    Alias of :func:`from_timestamp`, kept for backwards compatibility.
+
+    The argument is seconds since the Unix epoch rather than an epoch, so
+    `from_timestamp` is the more accurate name. It also avoids `epoch`
+    meaning two opposite things, since :attr:`Delorean.epoch` converts the
+    other way.
+    """
+    return from_timestamp(s)
 
 
 def flux():

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -58,16 +58,23 @@ local time shown above.
 
     >>> d.naive
     datetime.datetime(2013, 1, 12, 6, 10, 38, 102223)
-    >>> d.epoch
+    >>> d.timestamp
     1357971038.102223
 
 You can also create Delorean object using unix timestamps.
 
 .. doctest::
 
-    >>> from delorean import epoch
-    >>> epoch(1357971038.102223).shift("US/Eastern")
+    >>> from delorean import from_timestamp
+    >>> from_timestamp(1357971038.102223).shift("US/Eastern")
     Delorean(datetime=datetime.datetime(2013, 1, 12, 1, 10, 38, 102223), timezone='US/Eastern')
+
+.. note::
+
+    ``timestamp`` and ``from_timestamp`` were previously named ``epoch``. Both
+    old names still work and behave identically, but the new ones say what the
+    value actually is (seconds since the Unix epoch, not the epoch itself) and
+    avoid ``epoch`` meaning two opposite things.
 
 As you can see `delorean` returns a Delorean object which you can shift to the appropriate timezone to get back your original datetime object from above.
 

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -711,13 +711,27 @@ class DeloreanTests(unittest.TestCase):
         self.assertTrue(dt2 <= dt1)
         self.assertTrue(dt3 <= dt2)
 
-    def test_epoch(self):
-        unix_time = self.do.epoch
-        self.assertEqual(unix_time, 1357187474.148540)
+    def test_timestamp(self):
+        self.assertEqual(self.do.timestamp, 1357187474.148540)
 
-    def test_epoch_creation(self):
-        do = delorean.epoch(1357187474.148540)
+    def test_timestamp_matches_stdlib(self):
+        self.assertEqual(self.do.timestamp, self.do.datetime.timestamp())
+
+    def test_from_timestamp(self):
+        do = delorean.from_timestamp(1357187474.148540)
         self.assertEqual(self.do, do)
+
+    def test_from_timestamp_round_trips(self):
+        self.assertEqual(delorean.from_timestamp(self.do.timestamp), self.do)
+
+    def test_epoch_is_alias_of_timestamp(self):
+        self.assertEqual(self.do.epoch, self.do.timestamp)
+
+    def test_epoch_creation_is_alias_of_from_timestamp(self):
+        self.assertEqual(
+            delorean.epoch(1357187474.148540),
+            delorean.from_timestamp(1357187474.148540),
+        )
 
     def test_not_equal(self):
         d = delorean.Delorean()


### PR DESCRIPTION
Closes #86 and #85.

## 1. timestamp naming (#86)

`epoch` meant two opposite things: `Delorean.epoch` converted an object to a float, while `delorean.epoch(s)` converted a float to an object. It is also the wrong word, since the value is seconds *since* the epoch, which Python spells `datetime.timestamp()`.

Added `Delorean.timestamp` and `delorean.from_timestamp()` as the primary names. `epoch` and `epoch()` remain as identical aliases, so nothing breaks. No `DeprecationWarning` yet, since that commits to removal and belongs with a 2.0 decision.

## 2. Boundary properties now return Delorean (BREAKING)

`midnight`, `start_of_day` and `end_of_day` returned bare `datetime` objects because they did `return self._dt.replace(...)` without re-wrapping, unlike `replace()` and `shift()` nearby which do. That ended any chain.

They now return `Delorean`. **This breaks callers** doing `d.midnight.strftime(...)` or comparing against a `datetime`. Their docstrings also wrongly claimed they were "modifying the Delorean object"; corrected, with a test asserting they do not mutate.

## 3. Month and year boundaries (#85)

Added `start_of_month`, `end_of_month`, `start_of_year`, `end_of_year` as explicit properties returning `Delorean`:

```python
>>> Delorean(datetime(2013, 5, 15), timezone='US/Eastern').last_month().end_of_month
Delorean(datetime=datetime.datetime(2013, 4, 30, 23, 59, 59, 999999), timezone='US/Eastern')
```

`end_of_month` handles month length and leap years via `relativedelta(day=31)`. Scoped to month and year only: `week` needs a Monday/Sunday convention nobody has requested, and `hour`/`minute` duplicate `truncate()`. Written explicitly so they appear in the API reference, unlike the `next_*`/`last_*` family (#10).

## Verified locally

112 unit tests (was 102), 121 doctests (was 106), `html -W` clean, black and ruff clean.