### PR TITLE
Land boundary Delorean returns and month/year properties (stranded from #137)

### DIFF
--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -498,6 +498,103 @@ class Delorean(object):
             timezone=self.timezone,
         )
 
+    @property
+    def start_of_month(self):
+        """
+        Returns a new `Delorean` object for the first moment of the month
+        associated with this object. This object is left unchanged.
+
+        .. testsetup::
+
+            from datetime import datetime
+            from delorean import Delorean
+
+        .. doctest::
+
+            >>> d = Delorean(datetime(2015, 5, 15, 14, 30), timezone='UTC')
+            >>> d.start_of_month
+            Delorean(datetime=datetime.datetime(2015, 5, 1, 0, 0), timezone='UTC')
+
+        """
+        return Delorean(
+            datetime=self._dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0),
+            timezone=self.timezone,
+        )
+
+    @property
+    def end_of_month(self):
+        """
+        Returns a new `Delorean` object for the last moment of the month
+        associated with this object, accounting for month length and leap
+        years. This object is left unchanged.
+
+        .. testsetup::
+
+            from datetime import datetime
+            from delorean import Delorean
+
+        .. doctest::
+
+            >>> d = Delorean(datetime(2015, 2, 15, 14, 30), timezone='UTC')
+            >>> d.end_of_month
+            Delorean(datetime=datetime.datetime(2015, 2, 28, 23, 59, 59, 999999), timezone='UTC')
+
+        """
+        end = self._dt.replace(
+            hour=23, minute=59, second=59, microsecond=999999
+        ) + relativedelta(day=31)
+        return Delorean(datetime=end, timezone=self.timezone)
+
+    @property
+    def start_of_year(self):
+        """
+        Returns a new `Delorean` object for the first moment of the year
+        associated with this object. This object is left unchanged.
+
+        .. testsetup::
+
+            from datetime import datetime
+            from delorean import Delorean
+
+        .. doctest::
+
+            >>> d = Delorean(datetime(2015, 5, 15, 14, 30), timezone='UTC')
+            >>> d.start_of_year
+            Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 0), timezone='UTC')
+
+        """
+        return Delorean(
+            datetime=self._dt.replace(
+                month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+            ),
+            timezone=self.timezone,
+        )
+
+    @property
+    def end_of_year(self):
+        """
+        Returns a new `Delorean` object for the last moment of the year
+        associated with this object. This object is left unchanged.
+
+        .. testsetup::
+
+            from datetime import datetime
+            from delorean import Delorean
+
+        .. doctest::
+
+            >>> d = Delorean(datetime(2015, 5, 15, 14, 30), timezone='UTC')
+            >>> d.end_of_year
+            Delorean(datetime=datetime.datetime(2015, 12, 31, 23, 59, 59, 999999), timezone='UTC')
+
+        """
+        return Delorean(
+            datetime=self._dt.replace(
+                month=12, day=31, hour=23, minute=59, second=59, microsecond=999999
+            ),
+            timezone=self.timezone,
+        )
+
     def shift(self, timezone):
         """
         Shifts the timezone from the current timezone to the specified timezone associated with the Delorean object,

--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -433,8 +433,8 @@ class Delorean(object):
     @property
     def midnight(self):
         """
-        Returns midnight for datetime associated with
-        the Delorean object modifying the Delorean object.
+        Returns a new `Delorean` object for midnight of the day associated
+        with this object. This object is left unchanged.
 
         .. testsetup::
 
@@ -445,16 +445,19 @@ class Delorean(object):
 
             >>> d = Delorean(datetime(2015, 1, 1, 12), timezone='UTC')
             >>> d.midnight
-            datetime.datetime(2015, 1, 1, 0, 0, tzinfo=<UTC>)
+            Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 0), timezone='UTC')
 
         """
-        return self._dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        return Delorean(
+            datetime=self._dt.replace(hour=0, minute=0, second=0, microsecond=0),
+            timezone=self.timezone,
+        )
 
     @property
     def start_of_day(self):
         """
-        Returns the start of the day for datetime associated
-        with the Delorean object, modifying the Delorean object.
+        Returns a new `Delorean` object for the start of the day associated
+        with this object. This object is left unchanged.
 
         .. testsetup::
 
@@ -465,7 +468,7 @@ class Delorean(object):
 
             >>> d = Delorean(datetime(2015, 1, 1, 12), timezone='UTC')
             >>> d.start_of_day
-            datetime.datetime(2015, 1, 1, 0, 0, tzinfo=<UTC>)
+            Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 0), timezone='UTC')
 
         """
         return self.midnight
@@ -473,8 +476,8 @@ class Delorean(object):
     @property
     def end_of_day(self):
         """
-        Returns the end of the day for the datetime
-        associated with the Delorean object, modifying the Delorean object.
+        Returns a new `Delorean` object for the end of the day associated
+        with this object. This object is left unchanged.
 
         .. testsetup::
 
@@ -485,10 +488,15 @@ class Delorean(object):
 
             >>> d = Delorean(datetime(2015, 1, 1, 12), timezone='UTC')
             >>> d.end_of_day
-            datetime.datetime(2015, 1, 1, 23, 59, 59, 999999, tzinfo=<UTC>)
+            Delorean(datetime=datetime.datetime(2015, 1, 1, 23, 59, 59, 999999), timezone='UTC')
 
         """
-        return self._dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+        return Delorean(
+            datetime=self._dt.replace(
+                hour=23, minute=59, second=59, microsecond=999999
+            ),
+            timezone=self.timezone,
+        )
 
     def shift(self, timezone):
         """

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -158,7 +158,7 @@ Last Tuesday? Two Tuesdays ago at midnight? No problem.
     >>> d.last_tuesday()
     Delorean(datetime=datetime.datetime(2013, 1, 15, 19, 41, 6, 207481), timezone='UTC')
     >>> d.last_tuesday(2).midnight
-    datetime.datetime(2013, 1, 8, 0, 0, tzinfo=<UTC>)
+    Delorean(datetime=datetime.datetime(2013, 1, 8, 0, 0), timezone='UTC')
 
 
 Daylight Saving Transitions

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -209,6 +209,46 @@ returns the second, post-transition occurrence.
     side of a transition yourself.
 
 
+Period Boundaries
+^^^^^^^^^^^^^^^^^
+
+`Delorean` objects can give you the first or last moment of the day, month or
+year they fall in. Each returns a new `Delorean` object and leaves the original
+untouched, so they compose with the shift methods above.
+
+.. doctest::
+
+    >>> d = Delorean(datetime(2015, 5, 15, 14, 30), timezone='UTC')
+    >>> d.start_of_day
+    Delorean(datetime=datetime.datetime(2015, 5, 15, 0, 0), timezone='UTC')
+    >>> d.end_of_month
+    Delorean(datetime=datetime.datetime(2015, 5, 31, 23, 59, 59, 999999), timezone='UTC')
+    >>> d.start_of_year
+    Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 0), timezone='UTC')
+
+``end_of_month`` knows how long each month is, including February in a leap
+year.
+
+.. doctest::
+
+    >>> Delorean(datetime(2015, 2, 15), timezone='UTC').end_of_month
+    Delorean(datetime=datetime.datetime(2015, 2, 28, 23, 59, 59, 999999), timezone='UTC')
+    >>> Delorean(datetime(2024, 2, 15), timezone='UTC').end_of_month
+    Delorean(datetime=datetime.datetime(2024, 2, 29, 23, 59, 59, 999999), timezone='UTC')
+
+Because they return `Delorean` objects, they chain. The last day of the previous
+month is:
+
+.. doctest::
+
+    >>> Delorean(datetime(2013, 5, 15), timezone='US/Eastern').last_month().end_of_month
+    Delorean(datetime=datetime.datetime(2013, 4, 30, 23, 59, 59, 999999), timezone='US/Eastern')
+
+The full set is ``start_of_day``, ``end_of_day``, ``start_of_month``,
+``end_of_month``, ``start_of_year`` and ``end_of_year``, plus ``midnight``,
+which is an alias of ``start_of_day``.
+
+
 Replace Parts
 ^^^^^^^^^^^^^
 Using the `replace` method on `Delorean` objects, we can replace the `hour`, `minute`, `second`, `year` etc

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -208,6 +208,56 @@ class DeloreanTests(unittest.TestCase):
         # Still a Delorean, so the chain can continue.
         self.assertIsInstance(do.shift("US/Eastern"), delorean.Delorean)
 
+    def test_start_of_month(self):
+        do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
+        self.assertEqual(
+            do.start_of_month.datetime, datetime(2015, 5, 1, tzinfo=pytz.utc)
+        )
+
+    def test_end_of_month(self):
+        do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
+        self.assertEqual(
+            do.end_of_month.datetime,
+            datetime(2015, 5, 31, 23, 59, 59, 999999, tzinfo=pytz.utc),
+        )
+
+    def test_end_of_month_short_month(self):
+        do = delorean.Delorean(datetime(2015, 2, 15), timezone="UTC")
+        self.assertEqual(do.end_of_month.datetime.day, 28)
+
+    def test_end_of_month_leap_year(self):
+        do = delorean.Delorean(datetime(2024, 2, 15), timezone="UTC")
+        self.assertEqual(do.end_of_month.datetime.day, 29)
+
+    def test_start_of_year(self):
+        do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
+        self.assertEqual(
+            do.start_of_year.datetime, datetime(2015, 1, 1, tzinfo=pytz.utc)
+        )
+
+    def test_end_of_year(self):
+        do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
+        self.assertEqual(
+            do.end_of_year.datetime,
+            datetime(2015, 12, 31, 23, 59, 59, 999999, tzinfo=pytz.utc),
+        )
+
+    def test_last_day_of_previous_month(self):
+        # The use case from issue #85.
+        do = delorean.Delorean(datetime(2013, 5, 15, 14, 30), timezone="US/Eastern")
+        end = do.last_month().end_of_month
+        self.assertIsInstance(end, delorean.Delorean)
+        self.assertEqual(end.datetime.month, 4)
+        self.assertEqual(end.datetime.day, 30)
+
+    def test_month_and_year_boundaries_do_not_mutate(self):
+        before = self.do.datetime
+        self.do.start_of_month
+        self.do.end_of_month
+        self.do.start_of_year
+        self.do.end_of_year
+        self.assertEqual(self.do.datetime, before)
+
     def test_day_boundaries_do_not_mutate(self):
         before = self.do.datetime
         self.do.midnight

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -183,16 +183,37 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(self.do.naive, datetime(2013, 1, 3, 4, 0))
 
     def test_midnight(self):
-        dt = self.do.midnight
-        self.assertEqual(dt, datetime(2013, 1, 3, 0, 0, 0, tzinfo=pytz.utc))
+        do = self.do.midnight
+        self.assertIsInstance(do, delorean.Delorean)
+        self.assertEqual(do.datetime, datetime(2013, 1, 3, 0, 0, 0, tzinfo=pytz.utc))
 
     def test_start_of_day(self):
-        dt = self.do.start_of_day
-        self.assertEqual(dt, datetime(2013, 1, 3, 0, 0, 0, 0, tzinfo=pytz.utc))
+        do = self.do.start_of_day
+        self.assertIsInstance(do, delorean.Delorean)
+        self.assertEqual(do.datetime, datetime(2013, 1, 3, 0, 0, 0, 0, tzinfo=pytz.utc))
 
     def test_end_of_day(self):
-        dt = self.do.end_of_day
-        self.assertEqual(dt, datetime(2013, 1, 3, 23, 59, 59, 999999, tzinfo=pytz.utc))
+        do = self.do.end_of_day
+        self.assertIsInstance(do, delorean.Delorean)
+        self.assertEqual(
+            do.datetime, datetime(2013, 1, 3, 23, 59, 59, 999999, tzinfo=pytz.utc)
+        )
+
+    def test_day_boundaries_are_chainable(self):
+        do = self.do.last_month().end_of_day
+        self.assertIsInstance(do, delorean.Delorean)
+        self.assertEqual(
+            do.datetime, datetime(2012, 12, 3, 23, 59, 59, 999999, tzinfo=pytz.utc)
+        )
+        # Still a Delorean, so the chain can continue.
+        self.assertIsInstance(do.shift("US/Eastern"), delorean.Delorean)
+
+    def test_day_boundaries_do_not_mutate(self):
+        before = self.do.datetime
+        self.do.midnight
+        self.do.start_of_day
+        self.do.end_of_day
+        self.assertEqual(self.do.datetime, before)
 
     def test_truncation_second(self):
         self.do.truncate("second")


### PR DESCRIPTION
Recovers the two commits from #137 that never reached master.

#137 was merged while the branch still only contained the first commit (the `timestamp` naming for #86). The two commits below were pushed to the branch afterwards, so they landed nowhere. Master today still has the old `return self._dt.replace(...)` in `midnight` and none of the month/year properties

## Contents

**`feat: return new delorean objects for day boundary properties`** — `midnight`, `start_of_day` and `end_of_day` returned bare `datetime` because they never re-wrapped, unlike `replace()` and `shift()` nearby. They now return `Delorean`. **Breaking** for callers doing `d.midnight.strftime(...)`. Also corrects their docstrings, which wrongly claimed they modify the object, with a test proving they do not.

**`feat: add start and end of month and year properties`** — closes #85. Adds `start_of_month`, `end_of_month`, `start_of_year`, `end_of_year` as explicit properties returning `Delorean`, so the issue's request works:

```python
>>> Delorean(datetime(2013, 5, 15), timezone='US/Eastern').last_month().end_of_month
Delorean(datetime=datetime.datetime(2013, 4, 30, 23, 59, 59, 999999), timezone='US/Eastern')
```

`end_of_month` handles month length and leap years. Scoped to month and year only, written explicitly so they appear in the API reference.

## Verified

112 unit tests (master has 102), 121 doctests, black and ruff clean.

Closes #85.