### PR TITLE
Add configurable timezone assumptions to parse

### DIFF
--- a/delorean/interface.py
+++ b/delorean/interface.py
@@ -11,18 +11,38 @@ from .dates import Delorean, datetime_timezone, is_datetime_naive
 from .exceptions import DeloreanInvalidDatetime
 
 
-def parse(datetime_str, timezone=None, isofirst=True, dayfirst=True, yearfirst=True):
+def parse(
+    datetime_str,
+    timezone=None,
+    isofirst=True,
+    dayfirst=True,
+    yearfirst=True,
+    *,
+    assume_timezone="UTC",
+):
     """
-    Parses a datetime string and returns a `Delorean` object.
+    Parse a datetime string and return a `Delorean` object.
 
-    :param datetime_str: The string to be interpreted into a `Delorean` object.
-    :param timezone: Pass this parameter and the returned Delorean object will be normalized to this timezone. Any
-        offsets passed as part of datetime_str will be ignored.
-    :param isofirst: try to parse string as date in ISO format before everything else.
-    :param dayfirst: Whether to interpret the first value in an ambiguous 3-integer date (ex. 01/05/09) as the day
-        (True) or month (False). If yearfirst is set to True, this distinguishes between YDM and YMD.
-    :param yearfirst: Whether to interpret the first value in an ambiguous 3-integer date (ex. 01/05/09) as the
-        year. If True, the first number is taken to be the year, otherwise the last number is taken to be the year.
+    :param datetime_str: The string to interpret.
+    :param timezone: Force the parsed clock reading into this timezone. Any
+        offset in ``datetime_str`` is discarded. To supply a timezone only
+        when the string has none, use ``assume_timezone`` instead.
+    :param isofirst: Try ISO parsing before the general-purpose parser.
+    :param dayfirst: Interpret the first value in an ambiguous three-integer
+        date (for example, ``01/05/09``) as the day rather than the month.
+        When ``yearfirst`` is true, this distinguishes YDM from YMD.
+    :param yearfirst: Interpret the first value in an ambiguous three-integer
+        date as the year. Otherwise, interpret the last value as the year.
+    :param assume_timezone: A timezone name or object to apply when
+        ``datetime_str`` contains no timezone or UTC offset. It defaults to
+        ``"UTC"`` for compatibility with earlier versions. Pass ``None`` to
+        reject timezone-less input instead.
+    :raises DeloreanInvalidDatetime: If the string contains no timezone and
+        ``assume_timezone`` is ``None``.
+
+    .. versionadded:: 2.0
+        The ``assume_timezone`` parameter makes the existing UTC assumption
+        configurable and allows strict handling of timezone-less input.
 
     .. testsetup::
 
@@ -34,35 +54,49 @@ def parse(datetime_str, timezone=None, isofirst=True, dayfirst=True, yearfirst=T
         >>> parse('2015-01-01 00:01:02')
         Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone='UTC')
 
-    If a fixed offset is provided in the datetime_str, it will be parsed and the returned `Delorean` object will store a
-    `pytz.FixedOffest` as it's timezone.
+    If the string provides a fixed offset, the returned object keeps that
+    offset. No assumption is necessary.
 
     .. doctest::
 
         >>> parse('2015-01-01 00:01:02 -0800')
         Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone=pytz.FixedOffset(-480))
 
-    If the timezone argument is supplied, the returned Delorean object will be in the timezone supplied. Any offsets in
-    the datetime_str will be ignored.
+    A timezone-less string does not identify an instant by itself. For
+    compatibility, `Delorean` assumes UTC by default. Pass a different
+    ``assume_timezone`` when you know which timezone its clock reading uses.
+
+    .. doctest::
+
+        >>> parse('2015-01-01 00:01:02', assume_timezone='America/Toronto')
+        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone='America/Toronto')
+
+    Pass ``None`` when timezone-less input should be treated as an error rather
+    than an assumed UTC value.
+
+    .. doctest::
+
+        >>> parse('2015-01-01 00:01:02', assume_timezone=None)  # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        ...
+        DeloreanInvalidDatetime: ...
+
+    ``assume_timezone`` is only a fallback. It has no effect when the string
+    already includes a timezone or offset.
+
+    .. doctest::
+
+        >>> parse('2015-01-01 00:01:02 -0800', assume_timezone='UTC')
+        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone=pytz.FixedOffset(-480))
+
+    The older ``timezone`` argument is a stronger override: it discards any
+    parsed offset and treats the clock reading as local to the requested
+    timezone. When supplied, it takes precedence over ``assume_timezone``.
 
     .. doctest::
 
         >>> parse('2015-01-01 00:01:02 -0500', timezone='US/Pacific')
         Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone='US/Pacific')
-
-    If an unambiguous timezone is detected in the datetime string, a Delorean object with that datetime and
-    timezone will be returned.
-
-    .. doctest::
-
-        >>> parse('2015-01-01 00:01:02 -0800')
-        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone=pytz.FixedOffset(-480))
-
-    However if the provided timezone is ambiguous, parse will ignore the timezone and return a `Delorean` object in UTC
-    time.
-
-        >>> parse('2015-01-01 00:01:02 -0400')
-        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone=pytz.FixedOffset(-240))
 
     """
     # parse string to datetime object
@@ -79,8 +113,12 @@ def parse(datetime_str, timezone=None, isofirst=True, dayfirst=True, yearfirst=T
         dt = dt.replace(tzinfo=None)
         do = Delorean(datetime=dt, timezone=timezone)
     elif dt.tzinfo is None:
-        # assuming datetime object passed in is UTC
-        do = Delorean(datetime=dt, timezone="UTC")
+        if assume_timezone is None:
+            raise DeloreanInvalidDatetime(
+                "Unable to determine timezone; pass assume_timezone for "
+                "timezone-less input"
+            )
+        do = Delorean(datetime=dt, timezone=assume_timezone)
     elif isinstance(dt.tzinfo, tzoffset):
         utcoffset = dt.tzinfo.utcoffset(None)
         total_seconds = (

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -292,7 +292,8 @@ Though it might seem obvious `delorean` also provides truncation to the month an
 
 Strings and Parsing
 ^^^^^^^^^^^^^^^^^^^
-Another pain is dealing with strings of datetimes. `Delorean` can help you parse all the datetime strings you get from various APIs.
+Another pain is dealing with strings of datetimes. `Delorean` can help you
+parse the datetime strings you get from various APIs.
 
 .. doctest::
 
@@ -300,7 +301,60 @@ Another pain is dealing with strings of datetimes. `Delorean` can help you parse
     >>> parse("2011/01/01 00:00:00 -0700")
     Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone=pytz.FixedOffset(-420))
 
-As shown above if the string passed has offset data `delorean` will keep that offset as a ``pytz.FixedOffset`` timezone, if there is no timezone information passed in UTC is assumed.
+The ``-0700`` suffix tells us how this clock reading relates to UTC, so
+`Delorean` can identify the instant without making an assumption. It keeps the
+offset as a ``pytz.FixedOffset`` timezone.
+
+Timezone-less strings
+"""""""""""""""""""""
+
+Now consider the same clock reading without its offset:
+
+.. code-block:: text
+
+    2011/01/01 00:00:00
+
+This could mean midnight in Toronto, Tokyo, UTC, or somewhere else entirely.
+Those readings represent different instants. For compatibility with earlier
+versions, `Delorean` assumes that a timezone-less string is in UTC:
+
+.. doctest::
+
+    >>> parse("2011/01/01 00:00:00")
+    Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone='UTC')
+
+That default is convenient, but it is still an assumption rather than
+information found in the string. When you know what timezone the source
+intended, state it with ``assume_timezone``:
+
+.. doctest::
+
+    >>> parse("2011/01/01 00:00:00", assume_timezone="America/Toronto")
+    Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone='America/Toronto')
+
+If your application requires every input to provide its own timezone, pass
+``None``. This turns a missing timezone into an error instead of an assumption:
+
+.. doctest::
+
+    >>> parse("2011/01/01 00:00:00", assume_timezone=None)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    DeloreanInvalidDatetime: ...
+
+This option is deliberately a fallback. If a string already contains ``Z``,
+a numeric offset, or another recognized timezone, that information wins and
+``assume_timezone`` has no effect:
+
+.. doctest::
+
+    >>> parse("2011/01/01 00:00:00 -0700", assume_timezone="UTC")
+    Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone=pytz.FixedOffset(-420))
+
+This differs from the existing ``timezone`` argument, which deliberately
+overrides timezone data found in the string. When ``timezone`` is supplied, it
+takes precedence over ``assume_timezone``. In every successful case,
+``parse`` returns a `Delorean` object.
 
 
 Ambiguous cases
@@ -317,7 +371,9 @@ There might be cases where the string passed to parse is a bit ambiguous for exa
     - DD-MM-YY
     - MM-DD-YY
 
-So for example with default parameters `Delorean` will return '2013-05-06' as May 6th, 2013.
+For example, with the default date-order parameters `Delorean` reads
+``2013-05-06`` as May 6th, 2013. Because the string has no timezone, the
+default UTC assumption also applies.
 
 .. doctest::
 

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -349,7 +349,6 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(do.datetime, dt1)
 
     def test_parse_iso(self):
-        # https://github.com/myusuf3/delorean/issues/101
         do = delorean.parse("2017-05-02T05:38:49Z")
         dt1 = pytz.utc.localize(datetime(2017, 5, 2, 5, 38, 49))
         self.assertEqual(do.datetime, dt1)
@@ -364,13 +363,81 @@ class DeloreanTests(unittest.TestCase):
     def test_parse_with_invalid_datetime_string(self):
         self.assertRaises(ValueError, delorean.parse, "asd")
 
+    def test_parse_timezone_less_string_assumes_utc_by_default(self):
+        do = delorean.parse("2015-02-04T16:33:21.247513")
+
+        self.assertEqual(
+            do.datetime,
+            datetime(2015, 2, 4, 16, 33, 21, 247513, tzinfo=pytz.utc),
+        )
+
+    def test_parse_timezone_less_string_can_require_assumption(self):
+        with self.assertRaisesRegex(
+            delorean.DeloreanInvalidDatetime, "assume_timezone"
+        ):
+            delorean.parse(
+                "2015-02-04T16:33:21.247513",
+                assume_timezone=None,
+            )
+
+    def test_parse_with_assumed_utc_timezone(self):
+        do = delorean.parse("2015-02-04T16:33:21.247513", assume_timezone="UTC")
+
+        self.assertIsInstance(do, delorean.Delorean)
+        self.assertEqual(
+            do.datetime,
+            datetime(2015, 2, 4, 16, 33, 21, 247513, tzinfo=pytz.utc),
+        )
+
+    def test_parse_with_assumed_non_utc_timezone(self):
+        do = delorean.parse(
+            "2015-02-04T16:33:21.247513",
+            assume_timezone="America/Toronto",
+        )
+        expected = pytz.timezone("America/Toronto").localize(
+            datetime(2015, 2, 4, 16, 33, 21, 247513)
+        )
+
+        self.assertIsInstance(do, delorean.Delorean)
+        self.assertEqual(do.datetime, expected)
+
+    def test_parse_with_assumed_timezone_object(self):
+        timezone = pytz.timezone("America/Toronto")
+        do = delorean.parse(
+            "2015-02-04T16:33:21.247513",
+            assume_timezone=timezone,
+        )
+        expected = timezone.localize(datetime(2015, 2, 4, 16, 33, 21, 247513))
+
+        self.assertEqual(do.datetime, expected)
+
+    def test_parse_does_not_apply_assumed_timezone_to_aware_string(self):
+        do = delorean.parse(
+            "2015-02-04T16:33:21.247513-05:00",
+            assume_timezone="US/Pacific",
+        )
+
+        self.assertEqual(do.timezone, pytz.FixedOffset(-300))
+
+    def test_parse_timezone_override_takes_precedence_over_assumption(self):
+        do = delorean.parse(
+            "2015-02-04T16:33:21.247513-05:00",
+            timezone="US/Pacific",
+            assume_timezone="UTC",
+        )
+        expected = pytz.timezone("US/Pacific").localize(
+            datetime(2015, 2, 4, 16, 33, 21, 247513)
+        )
+
+        self.assertEqual(do.datetime, expected)
+
     def test_parse_with_utc_year_fill(self):
         do = delorean.parse("Thu Sep 25 10:36:28")
         dt1 = pytz.utc.localize(datetime(date.today().year, 9, 25, 10, 36, 28))
         self.assertEqual(do.datetime, dt1)
 
-    def test_parse_with_timezone_year_fill(self):
-        do = delorean.parse("Thu Sep 25 10:36:28")
+    def test_parse_with_assumed_timezone_year_fill(self):
+        do = delorean.parse("Thu Sep 25 10:36:28", assume_timezone="UTC")
         dt1 = pytz.utc.localize(datetime(date.today().year, 9, 25, 10, 36, 28))
         self.assertEqual(do.datetime, dt1)
         self.assertEqual(do.timezone.tzname(None), "UTC")


### PR DESCRIPTION
## Summary
- Add a keyword-only assume_timezone option for timezone-less strings.
- Keep UTC as the default so existing parse calls retain their 1.x behavior.
- Allow another timezone to be assumed, or None to reject timezone-less input.
- Preserve timezone data already present in the string and retain the existing timezone override behavior.
- Expand the API and quickstart documentation with executable examples.

## Tests
- uv run pytest -q (121 passed, 30 subtests passed)
- uv run ruff check delorean tests docs/conf.py
- uv run --group docs sphinx-build -b doctest docs docs/_build/doctest (126 passed)
- uv run --group docs sphinx-build -b html -W docs docs/_build/html

Fixes #53