### PR TITLE
Support non-pytz timezone objects and tighten parse errors

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -63,6 +63,14 @@ Needs a changelog line, most significant first:
   narrows what users can do, so it drives the version number (convention would
   be 1.1.0).
 - Boundary properties now return `Delorean` (breaking, see #139).
+- `parse()` gained a keyword-only `assume_timezone`, making the UTC assumption
+  for timezone-less strings configurable, or refusable with `None` (#53).
+- Non-pytz zones (`zoneinfo.ZoneInfo`, `datetime.timezone`) now work wherever a
+  timezone is accepted. `localize()`/`normalize()` called pytz-only methods, so
+  `now()` raised `AttributeError` under tzlocal 5.x, and `repr()` reported
+  `timezone=None` for a zoneinfo zone.
+- `DeloreanError` now subclasses `ValueError`, so one `except ValueError`
+  covers both delorean's errors and the parser's.
 - Build moved from `setup.py` to `pyproject.toml`/hatchling; version is
   single-sourced in `pyproject.toml`.
 - `Delorean.__getattr__` returned the `AttributeError` class instead of raising
@@ -198,7 +206,9 @@ mean a migration will fail loudly rather than silently changing answers.
   now exist with `epoch` as an alias. Removing the alias needs a
   `DeprecationWarning` first, which commits to a 2.0 timeline.
 - **#53** ISO 8601 strings with no offset are cast to UTC; reporter argues that
-  is wrong.
+  is wrong. Addressed by `parse(..., assume_timezone=...)`, which makes the
+  assumption explicit or refuses it. The issue's other suggestion, a flag on the
+  returned object recording that an assumption was made, was not implemented.
 - **#11** month-end arithmetic: shifting from the 31st into a shorter month
   clamps. Currently `next_month(2)` from Jan 31 gives Mar 31, not Mar 28, because
   the count is applied as a single `relativedelta` rather than iteratively, which

--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -150,7 +150,12 @@ def localize(dt, tz):
     if not isinstance(tz, tzinfo):
         tz = pytz.timezone(tz)
 
-    return tz.localize(dt)
+    # pytz zones carry no offset until localized; zoneinfo and stdlib zones
+    # resolve their own offset from the datetime they are attached to.
+    if hasattr(tz, "localize"):
+        return tz.localize(dt)
+
+    return dt.replace(tzinfo=tz)
 
 
 def normalize(dt, tz):
@@ -163,8 +168,11 @@ def normalize(dt, tz):
     """
     if not isinstance(tz, tzinfo):
         tz = pytz.timezone(tz)
-    dt = tz.normalize(dt)
-    return dt
+
+    if hasattr(tz, "normalize"):
+        return tz.normalize(dt)
+
+    return dt.astimezone(tz)
 
 
 class Delorean(object):
@@ -242,7 +250,9 @@ class Delorean(object):
         if isinstance(self.timezone, pytz._FixedOffset):
             tz = self.timezone
         else:
-            tz = self.timezone.tzname(None)
+            # pytz answers tzname(None) with the zone name; zoneinfo answers
+            # None, so fall back to its key.
+            tz = self.timezone.tzname(None) or str(self.timezone)
 
         return "Delorean(datetime=%r, timezone=%r)" % (dt, tz)
 

--- a/delorean/exceptions.py
+++ b/delorean/exceptions.py
@@ -1,6 +1,10 @@
-class DeloreanError(Exception):
+class DeloreanError(ValueError):
     """
     Base Delorean Exception class
+
+    Subclasses `ValueError` so that a caller handling bad input can catch
+    both these and the `ValueError` the underlying parser raises for
+    unreadable strings.
     """
 
     def __init__(self, msg):

--- a/delorean/interface.py
+++ b/delorean/interface.py
@@ -33,14 +33,15 @@ def parse(
         When ``yearfirst`` is true, this distinguishes YDM from YMD.
     :param yearfirst: Interpret the first value in an ambiguous three-integer
         date as the year. Otherwise, interpret the last value as the year.
-    :param assume_timezone: A timezone name or object to apply when
+    :param assume_timezone: A timezone name or ``tzinfo`` object to apply when
         ``datetime_str`` contains no timezone or UTC offset. It defaults to
         ``"UTC"`` for compatibility with earlier versions. Pass ``None`` to
-        reject timezone-less input instead.
+        assume nothing, which turns timezone-less input into an error.
     :raises DeloreanInvalidDatetime: If the string contains no timezone and
-        ``assume_timezone`` is ``None``.
+        ``assume_timezone`` is ``None``. `DeloreanInvalidDatetime` is a
+        `ValueError`, as is the error raised for an unreadable string.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.1.0
         The ``assume_timezone`` parameter makes the existing UTC assumption
         configurable and allows strict handling of timezone-less input.
 
@@ -115,8 +116,7 @@ def parse(
     elif dt.tzinfo is None:
         if assume_timezone is None:
             raise DeloreanInvalidDatetime(
-                "Unable to determine timezone; pass assume_timezone for "
-                "timezone-less input"
+                "datetime string has no timezone and assume_timezone is None"
             )
         do = Delorean(datetime=dt, timezone=assume_timezone)
     elif isinstance(dt.tzinfo, tzoffset):

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -9,6 +9,7 @@ import unittest
 from copy import deepcopy
 from datetime import date, datetime, timedelta, timezone, tzinfo
 from unittest import mock
+from zoneinfo import ZoneInfo
 
 import pytz
 from dateutil.parser import UnknownTimezoneWarning
@@ -431,6 +432,46 @@ class DeloreanTests(unittest.TestCase):
 
         self.assertEqual(do.datetime, expected)
 
+    def test_parse_timezone_override_applies_to_timezone_less_string(self):
+        do = delorean.parse(
+            "2015-02-04T16:33:21.247513",
+            timezone="US/Pacific",
+            assume_timezone=None,
+        )
+        expected = pytz.timezone("US/Pacific").localize(
+            datetime(2015, 2, 4, 16, 33, 21, 247513)
+        )
+
+        self.assertEqual(do.datetime, expected)
+
+    def test_parse_does_not_apply_assumed_timezone_to_utc_designator(self):
+        do = delorean.parse("2013-09-30T15:34:00.000Z", assume_timezone="US/Pacific")
+
+        self.assertEqual(do.datetime, pytz.utc.localize(datetime(2013, 9, 30, 15, 34)))
+
+    def test_parse_with_assumed_zoneinfo_timezone(self):
+        tz = ZoneInfo("America/Toronto")
+        do = delorean.parse("2015-02-04T16:33:21.247513", assume_timezone=tz)
+
+        self.assertEqual(
+            do.datetime,
+            datetime(2015, 2, 4, 16, 33, 21, 247513, tzinfo=tz),
+        )
+
+    def test_parse_with_assumed_timezone_resolves_nonexistent_local_time(self):
+        do = delorean.parse("2013-03-10T02:30:00", assume_timezone="US/Eastern")
+
+        self.assertEqual(do.datetime.tzname(), "EST")
+
+    def test_parse_with_assumed_timezone_resolves_ambiguous_local_time(self):
+        do = delorean.parse("2013-11-03T01:30:00", assume_timezone="US/Eastern")
+
+        self.assertEqual(do.datetime.tzname(), "EST")
+
+    def test_parse_strict_error_is_a_value_error(self):
+        with self.assertRaises(ValueError):
+            delorean.parse("2015-02-04T16:33:21.247513", assume_timezone=None)
+
     def test_parse_with_utc_year_fill(self):
         do = delorean.parse("Thu Sep 25 10:36:28")
         dt1 = pytz.utc.localize(datetime(date.today().year, 9, 25, 10, 36, 28))
@@ -838,6 +879,26 @@ class DeloreanTests(unittest.TestCase):
         dt = delorean.localize(datetime(2013, 11, 3, 1, 30), "US/Eastern")
         self.assertEqual(dt.tzname(), "EST")
 
+    def test_localize_with_zoneinfo_timezone(self):
+        tz = ZoneInfo("US/Eastern")
+        dt = delorean.localize(datetime(2013, 1, 1, 12), tz)
+
+        self.assertEqual(dt, datetime(2013, 1, 1, 12, tzinfo=tz))
+
+    def test_normalize_with_zoneinfo_timezone(self):
+        tz = ZoneInfo("US/Eastern")
+        dt = delorean.normalize(pytz.utc.localize(datetime(2013, 1, 1, 12)), tz)
+
+        self.assertEqual(dt, datetime(2013, 1, 1, 7, tzinfo=tz))
+
+    def test_now_with_zoneinfo_local_timezone(self):
+        # tzlocal 5.x hands back a zoneinfo zone rather than a pytz one.
+        tz = ZoneInfo("America/Toronto")
+        with mock.patch("delorean.interface.get_localzone", return_value=tz):
+            do = delorean.now()
+
+        self.assertEqual(do.timezone, tz)
+
     def test_datetime_localization(self):
         dt1 = self.do.datetime
         dt2 = delorean.Delorean(dt1).datetime
@@ -959,6 +1020,17 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(d1, d2)
         self.assertEqual(d1.datetime, d2.datetime)
         self.assertEqual(d1.timezone, d2.timezone)
+
+    def test_repr_zoneinfo_timezone(self):
+        d = delorean.Delorean(
+            datetime(2015, 1, 1), timezone=ZoneInfo("America/Toronto")
+        )
+
+        self.assertEqual(
+            repr(d),
+            "Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 0), "
+            "timezone='America/Toronto')",
+        )
 
     def test_timezone_delorean_to_datetime_to_delorean_utc(self):
         d1 = delorean.Delorean()


### PR DESCRIPTION
## Summary

Follow-up to #142. The `assume_timezone` review surfaced a real bug: `localize()` and `normalize()` called pytz-only methods (`tz.localize`, `tz.normalize`), which no other `tzinfo` implementation has. Since tzlocal 5.x returns a `zoneinfo.ZoneInfo`, `delorean.now()` raised `AttributeError` on master. No test covered `now()` unmocked, so CI stayed green.

## Changes

- `localize()` / `normalize()` fall back to `dt.replace(tzinfo=tz)` and `dt.astimezone(tz)` for non-pytz zones, so `ZoneInfo` and `datetime.timezone` work wherever a timezone is accepted — including `parse(..., assume_timezone=ZoneInfo(...))`, which the docstring already promised.
- `__repr__` falls back to the zone key: pytz answers `tzname(None)` with the zone name, `zoneinfo` answers `None`, so a fixed `now()` would otherwise print `timezone=None`.
- `DeloreanError` subclasses `ValueError`, so one `except ValueError` covers both delorean's errors and the parser's error for unreadable strings. Additive — existing `except DeloreanError` is unaffected.
- `parse()` docs: `versionadded` corrected from 2.0 to 1.1.0 (this is additive, and TASKS.md has 1.1.0 as next), `None` documented as "assume nothing" rather than reading as "unset", and the error message no longer tells the caller to pass the argument they just passed.
- Ten tests: the gaps left by #142 (`timezone=` + `assume_timezone=None` precedence, `Z` input, DST-ambiguous and nonexistent local times), `ValueError` catchability, and the zoneinfo paths including `now()` with a mocked local zone.
- TASKS.md: three release-note lines, and #53 now records that the issue's introspection suggestion was deliberately not implemented.

## Tests

- `uv run pytest -q` — 131 passed, 30 subtests
- `uv run ruff check delorean tests docs/conf.py`
- `uv run black --check delorean tests docs/conf.py`
- `uv run --group docs sphinx-build -b doctest docs docs/_build/doctest` — 126 passed
- `uv run --group docs sphinx-build -b html -W docs docs/_build/html`
