### PR TITLE
Document month-end shift clamping in the quickstart [11]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -81,7 +81,8 @@ Needs a changelog line, most significant first:
 - Trove classifiers restored; license switched to PEP 639 format.
 - Documentation corrections: quickstart wrongly claimed `parse()` converts
   offsets to UTC (it stores a `pytz.FixedOffset`) and wrongly documented
-  `.naive`. Documented how DST gaps and ambiguous times resolve.
+  `.naive`. Documented how DST gaps and ambiguous times resolve, and how
+  month-end shifts clamp (#11).
 - Note for #95: `delorean.dates.UTC` (the constant `UTC = "UTC"`) was removed in
   commit `afac86a`, first shipped in 0.6.0, and never documented. Mention it
   here as previously undocumented rather than inventing a retroactive 0.6.0
@@ -210,9 +211,11 @@ mean a migration will fail loudly rather than silently changing answers.
   assumption explicit or refuses it. The issue's other suggestion, a flag on the
   returned object recording that an assumption was made, was not implemented.
 - **#11** month-end arithmetic: shifting from the 31st into a shorter month
-  clamps. Currently `next_month(2)` from Jan 31 gives Mar 31, not Mar 28, because
-  the count is applied as a single `relativedelta` rather than iteratively, which
-  avoids drift.
+  clamps. `next_month(2)` from Jan 31 gives Mar 31, not Mar 28, because the count
+  is applied as a single `relativedelta` rather than iteratively, which avoids
+  drift. Now documented in the quickstart, which was the reporter's stated
+  minimum, and the issue is closed. A user-selectable policy object, his larger
+  ask, remains a 2.0 question if it is ever wanted.
 - **#96** business-day timedelta (feature request).
 - **#68** a 2015 open discussion thread; likely closeable.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -209,6 +209,56 @@ returns the second, post-transition occurrence.
     side of a transition yourself.
 
 
+Month-End Shifts
+""""""""""""""""
+
+Not every day of the month exists in every month, so shifting from the 31st
+needs a tie-breaking rule too. `Delorean` clamps to the last day of the target
+month.
+
+.. doctest::
+
+    >>> d = Delorean(datetime(2015, 1, 31), timezone='UTC')
+    >>> d.next_month()
+    Delorean(datetime=datetime.datetime(2015, 2, 28, 0, 0), timezone='UTC')
+
+A count is applied as one shift from the original date rather than as repeated
+one-month shifts, so the clamping does not accumulate. Two months from 31
+January is 31 March, because the shift is measured from 31 January both times.
+
+.. doctest::
+
+    >>> d.next_month(2)
+    Delorean(datetime=datetime.datetime(2015, 3, 31, 0, 0), timezone='UTC')
+
+Shifting one month at a time gives a different answer, because February's
+clamped result becomes the starting point for the second shift.
+
+.. doctest::
+
+    >>> d.next_month().next_month()
+    Delorean(datetime=datetime.datetime(2015, 3, 28, 0, 0), timezone='UTC')
+
+The same rule covers 29 February in a leap year.
+
+.. doctest::
+
+    >>> Delorean(datetime(2024, 2, 29), timezone='UTC').next_year()
+    Delorean(datetime=datetime.datetime(2025, 2, 28, 0, 0), timezone='UTC')
+
+.. note::
+
+    Clamping is a choice, not the only reasonable answer: rolling forward into
+    the first day of the next month is equally defensible. If you want the end
+    of the target month regardless of the day you started on, ask for it
+    explicitly with ``end_of_month`` rather than relying on the shift.
+
+.. doctest::
+
+    >>> d.next_month().end_of_month
+    Delorean(datetime=datetime.datetime(2015, 2, 28, 23, 59, 59, 999999), timezone='UTC')
+
+
 Period Boundaries
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary
This change adds documentation for how Delorean handles month-end arithmetic when shifting dates across shorter months. It explains the clamping behavior, shows how repeated single-month shifts differ from multi-month shifts, and notes the related leap-year behavior.

## Changes Made
- Added a new **Month-End Shifts** section to the quickstart guide.
- Documented that shifting from dates like January 31 clamps to the last valid day of the target month.
- Clarified that `next_month(2)` is applied as a single shift from the original date, avoiding cumulative drift.
- Added examples comparing `next_month(2)` with chaining `next_month().next_month()`.
- Documented leap-year handling for shifting from February 29 with `next_year()`.
- Added guidance that `end_of_month` should be used when the goal is the end of the target month regardless of the starting day.

## Files Modified
- `docs/quickstart.rst` — Added detailed documentation and examples for month-end shifting behavior.
- `TASKS.md` — Updated internal tracking notes to reflect the newly documented month-end shift behavior.

## Important Notes
- This is a documentation-only change; no runtime behavior was modified.
- The new examples may be useful for users validating date arithmetic expectations, especially around month-end and leap-year transitions.

Fixes #11