### PR TITLE
Migrate Delorean timezones to stdlib zoneinfo [79]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Delorean: Time Travel Made Easy
 
 `Delorean` is a library for clearing up the inconvenient truths that arise dealing with datetimes in Python. Understanding that timing is a delicate enough of a problem `delorean` hopes to provide a cleaner less troublesome solution to shifting, manipulating, and generating `datetimes`.
 
-Delorean stands on the shoulders of giants `pytz <http://pytz.sourceforge.net/>`_ and `dateutil <http://labix.org/python-dateutil>`_
+Delorean stands on the shoulders of giants: the standard library's `zoneinfo <https://docs.python.org/3/library/zoneinfo.html>`_ and `dateutil <https://dateutil.readthedocs.io/>`_
 
 `Delorean` will provide natural language improvements for manipulating time, as well as datetime abstractions for ease of use. The overall goal is to improve datetime manipulations, with a little bit of software and philosophy.
 
@@ -20,12 +20,12 @@ Here is the world without a flux capacitor at your side:
 
 .. code-block:: python
 
-    from datetime import datetime
-    import pytz
+    from datetime import datetime, timezone
+    from zoneinfo import ZoneInfo
 
-    est = pytz.timezone('US/Eastern')
-    d = datetime.now(pytz.utc)
-    d = est.normalize(d.astimezone(est))
+    est = ZoneInfo('US/Eastern')
+    d = datetime.now(timezone.utc)
+    d = d.astimezone(est)
     return d
 
 Now lets warm up the `delorean`:

--- a/TASKS.md
+++ b/TASKS.md
@@ -57,11 +57,27 @@ Everything from this session is unreleased, and `CHANGES.rst` has no entry for
 any of it. Issue #104 is someone explicitly asking for a release, open since
 2019.
 
+The version is now **2.0.0**: the pytz migration is a breaking interface
+change, which supersedes the 1.1.0 the Python 3.9 drop would have called for.
+
 Needs a changelog line, most significant first:
 
-- Dropped Python 3.9; `requires-python` is now `>=3.10`. The only change that
-  narrows what users can do, so it drives the version number (convention would
-  be 1.1.0).
+- **Timezones are standard library objects** (#79). `Delorean.timezone` returns
+  a `zoneinfo.ZoneInfo` for a named zone or a `datetime.timezone` for a fixed
+  offset, and `pytz` is gone from the dependency list. `delorean.timezone()`
+  and `delorean.utc` are the supported constructors, so callers no longer
+  import a timezone library themselves. Breaking for anyone comparing against
+  `pytz.utc` or catching `pytz.UnknownTimeZoneError`, which is now
+  `DeloreanInvalidTimezone`.
+- **Ambiguous local times resolve to the first occurrence**, following the
+  stdlib's `fold=0`, where 1.x took standard time via pytz's `is_dst=False`.
+  One hour per year, one hour different. Gap behaviour is unchanged.
+- `repr()` prints a fixed offset as `'UTC-08:00'` rather than
+  `pytz.FixedOffset(-480)`, and the constructor accepts that string, so repr
+  output still round-trips through `eval()`.
+- `localize()` now rejects an already-aware datetime rather than silently
+  moving the instant it represents.
+- Dropped Python 3.9; `requires-python` is now `>=3.10`.
 - Boundary properties now return `Delorean` (breaking, see #139).
 - `parse()` gained a keyword-only `assume_timezone`, making the UTC assumption
   for timezone-less strings configurable, or refusable with `None` (#53).
@@ -187,20 +203,25 @@ look and the custom sidebar templates.
 
 These travel together and want deciding as a set rather than one at a time.
 
-### Migrate off pytz to zoneinfo (#79)
+### Migrate off pytz to zoneinfo (#79) — done
 
-The largest and most disruptive item. pytz is maintained but superseded by stdlib
-`zoneinfo`. Delorean's public API is built on pytz semantics: it returns pytz
-timezone objects, exposes `pytz.FixedOffset` in `parse()`, and uses
-`localize()`/`normalize()` throughout. This is a breaking change warranting a
-2.0, not a cleanup.
+Landed for 2.0. The public API is now stdlib types throughout, `pytz` is off
+the dependency list, and `delorean.timezone()`/`delorean.utc` close the
+reporter's original ask.
 
-`tzlocal` 5.x already returns `zoneinfo.ZoneInfo` objects and delorean handles
-that fine, so the two coexist today.
+Worth recording how it went, since the approach transfers:
 
-Note `zoneinfo` resolves DST gaps and ambiguity via the `fold` attribute under
-different rules than pytz's `is_dst=False`. The tests added for that behaviour
-mean a migration will fail loudly rather than silently changing answers.
+- `tests/behavior_tests.py` was written first, describing behaviour in terms of
+  instants, offsets, zone names and types rather than pytz objects. All 82 held
+  through the core rewrite, which is what made the migration verifiable rather
+  than hopeful.
+- That net caught two live bugs before the migration started: `normalize()`
+  rejected any datetime delorean had localized with a zoneinfo zone, and
+  `localize()` silently overwrote the timezone of an already-aware datetime,
+  changing the instant.
+- The `fold` difference was the only genuine semantic break, and it was decided
+  deliberately rather than discovered. Gaps resolve identically; only the
+  duplicated autumn hour moved.
 
 ### Related open issues
 

--- a/delorean/__init__.py
+++ b/delorean/__init__.py
@@ -29,7 +29,11 @@ from delorean.dates import (
     move_datetime_year,
     normalize,
 )
-from delorean.exceptions import DeloreanInvalidDatetime, DeloreanInvalidTimezone
+from delorean.exceptions import (
+    DeloreanError,
+    DeloreanInvalidDatetime,
+    DeloreanInvalidTimezone,
+)
 from delorean.interface import (
     epoch,
     flux,
@@ -43,3 +47,4 @@ from delorean.interface import (
     stops,
     utcnow,
 )
+from delorean.timezones import timezone, utc

--- a/delorean/dates.py
+++ b/delorean/dates.py
@@ -1,16 +1,16 @@
 import sys
-from datetime import datetime, timedelta, timezone, tzinfo
+from datetime import datetime, timedelta, timezone
 from functools import partial, update_wrapper
 from operator import index
 
 import humanize
-import pytz
 from babel.dates import format_datetime
 from dateutil.relativedelta import relativedelta
-from dateutil.tz import tzoffset
 from tzlocal import get_localzone
 
 from .exceptions import DeloreanInvalidDatetime, DeloreanInvalidTimezone
+from .timezones import timezone as get_timezone
+from .timezones import utc
 
 
 def get_total_second(td):
@@ -147,11 +147,15 @@ def localize(dt, tz):
     Given a naive datetime object this method will return a localized
     datetime object
     """
-    if not isinstance(tz, tzinfo):
-        tz = pytz.timezone(tz)
+    tz = get_timezone(tz)
 
-    # pytz zones carry no offset until localized; zoneinfo and stdlib zones
-    # resolve their own offset from the datetime they are attached to.
+    # Attaching a zone to an already-aware datetime would move the instant it
+    # represents rather than describe it, so refuse rather than guess.
+    if dt.tzinfo is not None:
+        raise DeloreanInvalidDatetime("localize requires a naive datetime")
+
+    # A pytz zone from a caller still on 1.x carries no offset until localized;
+    # attaching one directly would silently yield that zone's LMT offset.
     if hasattr(tz, "localize"):
         return tz.localize(dt)
 
@@ -166,13 +170,8 @@ def normalize(dt, tz):
     This means take the give localized datetime and returns the
     datetime normalized to match the specified timezone.
     """
-    if not isinstance(tz, tzinfo):
-        tz = pytz.timezone(tz)
+    tz = get_timezone(tz)
 
-    # astimezone is the conversion that works for every tzinfo implementation.
-    # pytz's own normalize() reaches into the *incoming* datetime's tzinfo for
-    # pytz internals, so it rejects any datetime delorean localized with a
-    # zoneinfo zone.
     if dt.tzinfo is None:
         raise DeloreanInvalidDatetime("normalize requires an aware datetime")
 
@@ -211,18 +210,7 @@ class Delorean(object):
         if datetime:
             if is_datetime_naive(datetime):
                 if timezone:
-                    if isinstance(timezone, tzoffset):
-                        utcoffset = timezone.utcoffset(None)
-                        total_seconds = (
-                            utcoffset.microseconds
-                            + (utcoffset.seconds + utcoffset.days * 24 * 3600) * 10**6
-                        ) / 10**6
-                        self._tzinfo = pytz.FixedOffset(total_seconds / 60)
-                    elif isinstance(timezone, tzinfo):
-                        self._tzinfo = timezone
-                    else:
-                        self._tzinfo = pytz.timezone(timezone)
-                    self._dt = localize(datetime, self._tzinfo)
+                    self._dt = localize(datetime, timezone)
                     self._tzinfo = self._dt.tzinfo
                 else:
                     # TODO(mlew, 2015-08-09):
@@ -234,31 +222,18 @@ class Delorean(object):
                 self._dt = datetime
         else:
             if timezone:
-                if isinstance(timezone, tzoffset):
-                    self._tzinfo = pytz.FixedOffset(
-                        timezone.utcoffset(None).total_seconds() / 60
-                    )
-                elif isinstance(timezone, tzinfo):
-                    self._tzinfo = timezone
-                else:
-                    self._tzinfo = pytz.timezone(timezone)
-
+                self._tzinfo = get_timezone(timezone)
                 self._dt = datetime_timezone(self._tzinfo)
                 self._tzinfo = self._dt.tzinfo
             else:
-                self._tzinfo = pytz.utc
-                self._dt = datetime_timezone("UTC")
+                self._tzinfo = utc
+                self._dt = datetime_timezone(utc)
 
     def __repr__(self):
         dt = self.datetime.replace(tzinfo=None)
-        if isinstance(self.timezone, pytz._FixedOffset):
-            tz = self.timezone
-        else:
-            # pytz answers tzname(None) with the zone name; zoneinfo answers
-            # None, so fall back to its key.
-            tz = self.timezone.tzname(None) or str(self.timezone)
-
-        return "Delorean(datetime=%r, timezone=%r)" % (dt, tz)
+        # Both zoneinfo zones and fixed offsets render as something timezone()
+        # accepts, so this stays round-trippable through eval().
+        return "Delorean(datetime=%r, timezone=%r)" % (dt, str(self.timezone))
 
     def __eq__(self, other):
         if isinstance(other, Delorean):
@@ -361,8 +336,9 @@ class Delorean(object):
     @property
     def timezone(self):
         """
-        Returns a valid tzinfo object associated with
-        the Delorean object.
+        Returns the tzinfo object associated with the Delorean object: a
+        `zoneinfo.ZoneInfo` for a named zone, or a `datetime.timezone` for a
+        fixed offset.
 
         .. testsetup::
 
@@ -373,7 +349,13 @@ class Delorean(object):
 
             >>> d = Delorean(datetime(2015, 1, 1), timezone='UTC')
             >>> d.timezone
-            <UTC>
+            zoneinfo.ZoneInfo(key='UTC')
+
+        .. versionchanged:: 2.0
+            Timezones are standard library objects. Earlier versions returned
+            `pytz` objects, so comparisons against `pytz.utc` and friends need
+            updating to :func:`delorean.timezone` or `zoneinfo.ZoneInfo`.
+
         """
         return self._tzinfo
 
@@ -634,10 +616,10 @@ class Delorean(object):
 
         """
         try:
-            self._tzinfo = pytz.timezone(timezone)
-        except pytz.UnknownTimeZoneError:
-            raise DeloreanInvalidTimezone("Provide a valid timezone")
-        self._dt = self._tzinfo.normalize(self._dt.astimezone(self._tzinfo))
+            self._tzinfo = get_timezone(timezone)
+        except DeloreanInvalidTimezone:
+            raise DeloreanInvalidTimezone("Provide a valid timezone") from None
+        self._dt = self._dt.astimezone(self._tzinfo)
         self._tzinfo = self._dt.tzinfo
         return self
 
@@ -660,7 +642,7 @@ class Delorean(object):
 
         """
         epoch_sec = datetime.fromtimestamp(0, timezone.utc)
-        now_sec = pytz.utc.normalize(self._dt)
+        now_sec = self._dt.astimezone(utc)
         delta_sec = now_sec - epoch_sec
         return get_total_second(delta_sec)
 
@@ -722,7 +704,7 @@ class Delorean(object):
 
             >>> d = Delorean(datetime(2015, 1, 1, 12, 15), timezone='UTC')
             >>> d.datetime
-            datetime.datetime(2015, 1, 1, 12, 15, tzinfo=<UTC>)
+            datetime.datetime(2015, 1, 1, 12, 15, tzinfo=zoneinfo.ZoneInfo(key='UTC'))
         """
         return self._dt
 

--- a/delorean/interface.py
+++ b/delorean/interface.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone
 
-import pytz
 from dateutil.parser import isoparse as isocapture
 from dateutil.parser import parse as capture
 from dateutil.rrule import DAILY, HOURLY, MONTHLY, YEARLY, rrule
@@ -9,6 +8,8 @@ from tzlocal import get_localzone
 
 from .dates import Delorean, datetime_timezone, is_datetime_naive
 from .exceptions import DeloreanInvalidDatetime
+from .timezones import timezone as get_timezone
+from .timezones import utc
 
 
 def parse(
@@ -61,7 +62,7 @@ def parse(
     .. doctest::
 
         >>> parse('2015-01-01 00:01:02 -0800')
-        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone=pytz.FixedOffset(-480))
+        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone='UTC-08:00')
 
     A timezone-less string does not identify an instant by itself. For
     compatibility, `Delorean` assumes UTC by default. Pass a different
@@ -88,7 +89,7 @@ def parse(
     .. doctest::
 
         >>> parse('2015-01-01 00:01:02 -0800', assume_timezone='UTC')
-        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone=pytz.FixedOffset(-480))
+        Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 1, 2), timezone='UTC-08:00')
 
     The older ``timezone`` argument is a stronger override: it discards any
     parsed offset and treats the clock reading as local to the requested
@@ -120,13 +121,7 @@ def parse(
             )
         do = Delorean(datetime=dt, timezone=assume_timezone)
     elif isinstance(dt.tzinfo, tzoffset):
-        utcoffset = dt.tzinfo.utcoffset(None)
-        total_seconds = (
-            utcoffset.microseconds
-            + (utcoffset.seconds + utcoffset.days * 24 * 3600) * 10**6
-        ) / 10**6
-
-        tz = pytz.FixedOffset(total_seconds / 60)
+        tz = get_timezone(dt.tzinfo)
         dt = dt.replace(tzinfo=None)
         do = Delorean(dt, timezone=tz)
     elif isinstance(dt.tzinfo, tzlocal):
@@ -134,12 +129,12 @@ def parse(
         dt = dt.replace(tzinfo=None)
         do = Delorean(dt, timezone=tz)
     else:
-        dt = pytz.utc.normalize(dt)
+        dt = dt.astimezone(utc)
         # making dt naive so we can pass it to Delorean
         dt = dt.replace(tzinfo=None)
         # if parse string has tzinfo we return a normalized UTC
         # delorean object that represents the time.
-        do = Delorean(datetime=dt, timezone="UTC")
+        do = Delorean(datetime=dt, timezone=utc)
 
     return do
 

--- a/delorean/timezones.py
+++ b/delorean/timezones.py
@@ -1,0 +1,69 @@
+"""
+Timezone objects for delorean's public API.
+
+Every timezone delorean hands back is a standard library object: a
+`zoneinfo.ZoneInfo` for a named zone, or a `datetime.timezone` for a fixed
+offset. `timezone` is the only constructor a caller needs, so working with
+`Delorean` objects never means importing a timezone library of your own.
+"""
+
+import re
+from datetime import timedelta, tzinfo
+from datetime import timezone as fixed_offset
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from dateutil.tz import tzoffset
+
+from .exceptions import DeloreanInvalidTimezone
+
+utc = ZoneInfo("UTC")
+
+# `str(datetime.timezone(...))` renders a fixed offset in this form, which is
+# what `Delorean.__repr__` prints, so repr output round-trips back through
+# `timezone()`.
+_OFFSET = re.compile(r"^UTC([+-])(\d{2}):(\d{2})(?::(\d{2}))?$")
+
+
+def timezone(name):
+    """
+    Return the timezone that `name` identifies.
+
+    :param name: An IANA zone name such as ``"US/Eastern"``, a fixed offset
+        written as ``"UTC-08:00"``, or a `tzinfo` object, which is returned
+        unchanged so this can normalize whatever a caller supplies.
+    :raises DeloreanInvalidTimezone: If the name identifies no known zone.
+
+    .. testsetup::
+
+        from delorean import timezone
+
+    .. doctest::
+
+        >>> timezone('US/Eastern')
+        zoneinfo.ZoneInfo(key='US/Eastern')
+        >>> timezone('UTC-08:00')
+        datetime.timezone(datetime.timedelta(days=-1, seconds=57600))
+
+    .. versionadded:: 2.0
+
+    """
+    if isinstance(name, tzoffset):
+        # dateutil's offsets reach here from parsed strings; convert them so
+        # every fixed offset delorean stores is the same type.
+        return fixed_offset(name.utcoffset(None))
+
+    if isinstance(name, tzinfo):
+        return name
+
+    match = _OFFSET.match(name) if isinstance(name, str) else None
+    if match:
+        sign, hours, minutes, seconds = match.groups()
+        offset = timedelta(
+            hours=int(hours), minutes=int(minutes), seconds=int(seconds or 0)
+        )
+        return fixed_offset(-offset if sign == "-" else offset)
+
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError, TypeError):
+        raise DeloreanInvalidTimezone(f"Unknown timezone: {name!r}") from None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ This document describes Delorean v\ |version|.
 
 `Delorean` is a library for clearing up the inconvenient truths that arise dealing with datetimes in Python. Understanding that timing is a delicate enough of a problem `delorean` hopes to provide a cleaner less troublesome solution to shifting, manipulating, generating `datetimes`.
 
-Delorean stands on the shoulders of giants `pytz <http://pytz.sourceforge.net/>`_ and `dateutil <http://labix.org/python-dateutil>`_
+Delorean stands on the shoulders of giants: the standard library's `zoneinfo <https://docs.python.org/3/library/zoneinfo.html>`_ and `dateutil <https://dateutil.readthedocs.io/>`_
 
 `Delorean` will provide natural language improvements for manipulating time, as well as datetime abstractions for ease of use. The overall goal is to improve datetime manipulations, with a little bit of software and philosophy.
 
@@ -24,6 +24,21 @@ Pretty much make you a badass, time traveller.
 
 Interface Update
 ^^^^^^^^^^^^^^^^
+Version 2.0.0 moves every timezone to the standard library. If you are coming from 1.x:
+
+- `Delorean.timezone` now returns a `zoneinfo.ZoneInfo` or a
+  `datetime.timezone`, so comparisons like ``d.timezone == pytz.utc`` need to
+  become ``d.timezone == delorean.utc``.
+- `delorean.timezone` and `delorean.utc` are the supported way to build a
+  timezone, and `pytz` is no longer a dependency.
+- A local time that happens twice, on the autumn daylight saving transition,
+  now resolves to the first of its two occurrences rather than to standard
+  time. Times inside the spring gap are unchanged.
+- An unknown timezone name raises `DeloreanInvalidTimezone`, which is a
+  `ValueError`, instead of `pytz.UnknownTimeZoneError`.
+- `localize` refuses an already-aware datetime instead of silently moving the
+  instant it represents.
+
 Version 1.0.0 introduces the following breaking changes:
     - `Delorean.epoch` is a property, not a function.
     - `Delorean.midnight` is a property, not a function.
@@ -37,12 +52,12 @@ Getting Started
 
 Here is the world without a flux capacitor at your side.::
 
-    from datetime import datetime
-    import pytz
+    from datetime import datetime, timezone
+    from zoneinfo import ZoneInfo
 
-    est = pytz.timezone('US/Eastern')
-    d = datetime.now(pytz.utc)
-    d = est.normalize(d.astimezone(est))
+    est = ZoneInfo('US/Eastern')
+    d = datetime.now(timezone.utc)
+    d = d.astimezone(est)
     d
 
 Now lets warm up the `delorean`::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -46,7 +46,7 @@ Now that you have successfully shifted the timezone you can easily return a loca
 .. doctest::
 
     >>> d.datetime
-    datetime.datetime(2013, 1, 12, 1, 10, 38, 102223, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+    datetime.datetime(2013, 1, 12, 1, 10, 38, 102223, tzinfo=zoneinfo.ZoneInfo(key='US/Eastern'))
     >>> d.date
     datetime.date(2013, 1, 12)
 
@@ -95,17 +95,57 @@ As you can see `delorean` returns a Delorean object which you can shift to the a
 .. doctest::
 
     >>> from datetime import datetime
-    >>> from pytz import timezone
+    >>> from delorean import timezone
     >>> tz = timezone("US/Pacific")
-    >>> dt = tz.localize(datetime(2013, 3, 16, 5, 28, 11, 536818))
+    >>> dt = datetime(2013, 3, 16, 5, 28, 11, 536818, tzinfo=tz)
     >>> dt
-    datetime.datetime(2013, 3, 16, 5, 28, 11, 536818, tzinfo=<DstTzInfo 'US/Pacific' PDT-1 day, 17:00:00 DST>)
+    datetime.datetime(2013, 3, 16, 5, 28, 11, 536818, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific'))
     >>> d = Delorean(datetime=dt)
     >>> d
     Delorean(datetime=datetime.datetime(2013, 3, 16, 5, 28, 11, 536818), timezone='US/Pacific')
     >>> d = Delorean(datetime=dt, timezone="US/Eastern")
     >>> d
     Delorean(datetime=datetime.datetime(2013, 3, 16, 5, 28, 11, 536818), timezone='US/Pacific')
+
+Timezones
+^^^^^^^^^
+
+Every timezone `delorean` hands back is a standard library object, so nothing
+you get from a `Delorean` requires a timezone library of your own. Named zones
+come back as `zoneinfo.ZoneInfo`, and `delorean.timezone` builds them for you.
+
+.. doctest::
+
+    >>> from delorean import timezone, utc
+    >>> timezone("US/Eastern")
+    zoneinfo.ZoneInfo(key='US/Eastern')
+    >>> Delorean(datetime(2015, 1, 1), timezone="UTC").timezone == utc
+    True
+
+A fixed offset is a `datetime.timezone`. Write it the way it prints, and
+`delorean` will read it back:
+
+.. doctest::
+
+    >>> timezone("UTC-08:00").utcoffset(None)
+    datetime.timedelta(days=-1, seconds=57600)
+    >>> Delorean(datetime(2015, 1, 1), timezone="UTC-08:00")
+    Delorean(datetime=datetime.datetime(2015, 1, 1, 0, 0), timezone='UTC-08:00')
+
+A name that identifies no zone raises, rather than returning something
+approximate:
+
+.. doctest::
+
+    >>> timezone("Not/AZone")  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    DeloreanInvalidTimezone: ...
+
+.. versionadded:: 2.0
+    ``timezone`` and ``utc``. Earlier versions returned `pytz` objects, which
+    meant importing `pytz` yourself to compare or construct a timezone.
+
 
 Time Arithmetic
 ^^^^^^^^^^^^^^^
@@ -171,14 +211,14 @@ EDT, which means the shift advanced 23 actual hours rather than 24.
 
 .. doctest::
 
-    >>> from pytz import timezone
+    >>> from delorean import timezone
     >>> eastern = timezone("US/Eastern")
-    >>> d = Delorean(eastern.localize(datetime(2013, 3, 9, 7, 0)))
-    >>> d.next_day().datetime
-    datetime.datetime(2013, 3, 10, 7, 0, tzinfo=<DstTzInfo 'US/Eastern' EDT-1 day, 20:00:00 DST>)
+    >>> d = Delorean(datetime(2013, 3, 9, 7, 0), timezone=eastern)
+    >>> d.next_day().datetime.strftime("%Y-%m-%d %H:%M %Z")
+    '2013-03-10 07:00 EDT'
 
-Two kinds of local time need a tie-breaking rule, and `delorean` resolves both
-of them to **standard** time.
+Two kinds of local time need a tie-breaking rule, and `delorean` follows the
+standard library: a naive datetime carries ``fold=0``.
 
 A local time inside the spring-forward gap never happens. On 10 March 2013 the
 Eastern clocks jumped straight from 02:00 EST to 03:00 EDT, so 02:30 has no
@@ -187,26 +227,31 @@ local reading at all. Shifting into it returns 02:30 EST, which is the instant
 
 .. doctest::
 
-    >>> d = Delorean(eastern.localize(datetime(2013, 3, 9, 2, 30)))
-    >>> d.next_day().datetime
-    datetime.datetime(2013, 3, 10, 2, 30, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+    >>> d = Delorean(datetime(2013, 3, 9, 2, 30), timezone=eastern)
+    >>> d.next_day().datetime.strftime("%Y-%m-%d %H:%M %Z")
+    '2013-03-10 02:30 EST'
 
 A local time inside the autumn fall-back happens twice. On 3 November 2013,
 01:30 occurs once as EDT and then again an hour later as EST. Shifting into it
-returns the second, post-transition occurrence.
+returns the **first** of the two, which is the daylight side.
 
 .. doctest::
 
-    >>> d = Delorean(eastern.localize(datetime(2013, 11, 2, 1, 30)))
-    >>> d.next_day().datetime
-    datetime.datetime(2013, 11, 3, 1, 30, tzinfo=<DstTzInfo 'US/Eastern' EST-1 day, 19:00:00 STD>)
+    >>> d = Delorean(datetime(2013, 11, 2, 1, 30), timezone=eastern)
+    >>> d.next_day().datetime.strftime("%Y-%m-%d %H:%M %Z")
+    '2013-11-03 01:30 EDT'
 
 .. note::
 
     This rule is not specific to shifting. It applies wherever `delorean`
-    localizes a naive datetime, because it comes from `pytz`'s ``is_dst=False``
-    default. Pass an already-localized datetime if you need to choose the other
-    side of a transition yourself.
+    localizes a naive datetime, because it comes from the ``fold`` attribute
+    described in :pep:`495`. Pass an already-aware datetime, built with
+    ``fold=1``, when you need the other side of a transition.
+
+.. versionchanged:: 2.0
+    1.x resolved an ambiguous local time to standard time, because `pytz`
+    defaulted to ``is_dst=False``. The same input now resolves to the first
+    occurrence, which is daylight time. Gap behaviour is unchanged.
 
 
 Month-End Shifts
@@ -349,11 +394,11 @@ parse the datetime strings you get from various APIs.
 
     >>> from delorean import parse
     >>> parse("2011/01/01 00:00:00 -0700")
-    Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone=pytz.FixedOffset(-420))
+    Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone='UTC-07:00')
 
 The ``-0700`` suffix tells us how this clock reading relates to UTC, so
 `Delorean` can identify the instant without making an assumption. It keeps the
-offset as a ``pytz.FixedOffset`` timezone.
+offset as a `datetime.timezone`, which prints as ``UTC-07:00``.
 
 Timezone-less strings
 """""""""""""""""""""
@@ -399,7 +444,7 @@ a numeric offset, or another recognized timezone, that information wins and
 .. doctest::
 
     >>> parse("2011/01/01 00:00:00 -0700", assume_timezone="UTC")
-    Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone=pytz.FixedOffset(-420))
+    Delorean(datetime=datetime.datetime(2011, 1, 1, 0, 0), timezone='UTC-07:00')
 
 This differs from the existing ``timezone`` argument, which deliberately
 overrides timezone data found in the string. When ``timezone`` is supplied, it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delorean"
-version = "1.0.1"
+version = "2.0.0"
 description = "library for manipulating datetimes with ease and clarity"
 readme = "README.rst"
 license = "MIT"
@@ -25,7 +25,6 @@ dependencies = [
     "babel>=2.10.3",
     "humanize>=4.2.2",
     "python-dateutil>=2.8.2",
-    "pytz>=2022.1",
     "tzlocal>=4.2",
 ]
 

--- a/tests/behavior_tests.py
+++ b/tests/behavior_tests.py
@@ -187,10 +187,10 @@ class DaylightSavingTieBreaks(unittest.TestCase):
     """
     How delorean resolves local times that are missing or duplicated.
 
-    These encode the answers the pytz era gives. A timezone migration changes
-    the mechanism (pytz's ``is_dst=False`` versus the stdlib's ``fold``), so
-    these are the tests that must be consciously re-decided rather than
-    quietly updated.
+    2.0 follows the standard library: a naive datetime carries ``fold=0``, so a
+    duplicated local time means the first of its two occurrences, and a missing
+    one is read against the offset in force before the transition. The gap
+    answers match the pytz era exactly; the ambiguous ones deliberately do not.
     """
 
     def test_shifting_across_a_transition_keeps_the_wall_clock(self):
@@ -210,12 +210,12 @@ class DaylightSavingTieBreaks(unittest.TestCase):
             utc_instant(do), datetime(2013, 3, 10, 7, 30, tzinfo=timezone.utc)
         )
 
-    def test_ambiguous_local_time_resolves_to_standard_time(self):
+    def test_ambiguous_local_time_takes_the_first_occurrence(self):
         do = delorean.Delorean(FALL_AMBIGUOUS_NAIVE, timezone=EASTERN)
 
-        self.assertEqual(do.datetime.tzname(), "EST")
+        self.assertEqual(do.datetime.tzname(), "EDT")
         self.assertEqual(
-            utc_instant(do), datetime(2013, 11, 3, 6, 30, tzinfo=timezone.utc)
+            utc_instant(do), datetime(2013, 11, 3, 5, 30, tzinfo=timezone.utc)
         )
 
     def test_parse_resolves_a_nonexistent_local_time_the_same_way(self):
@@ -226,7 +226,7 @@ class DaylightSavingTieBreaks(unittest.TestCase):
     def test_parse_resolves_an_ambiguous_local_time_the_same_way(self):
         do = delorean.parse("2013-11-03T01:30:00", assume_timezone=EASTERN)
 
-        self.assertEqual(do.datetime.tzname(), "EST")
+        self.assertEqual(do.datetime.tzname(), "EDT")
 
 
 class Shifting(unittest.TestCase):

--- a/tests/delorean_tests.py
+++ b/tests/delorean_tests.py
@@ -11,7 +11,6 @@ from datetime import date, datetime, timedelta, timezone, tzinfo
 from unittest import mock
 from zoneinfo import ZoneInfo
 
-import pytz
 from dateutil.parser import UnknownTimezoneWarning
 from dateutil.tz import tzlocal, tzoffset
 
@@ -39,7 +38,7 @@ class GenericUTC(tzinfo):
 
 UTC = "UTC"
 generic_utc = GenericUTC()
-est = pytz.timezone("US/Eastern").localize(naive_utcnow()).tzinfo
+est = naive_utcnow().replace(tzinfo=ZoneInfo("US/Eastern")).tzinfo
 
 
 class DeloreanTests(unittest.TestCase):
@@ -61,21 +60,21 @@ class DeloreanTests(unittest.TestCase):
         do = delorean.Delorean(datetime=aware_dt_generic)
         self.assertTrue(isinstance(do, delorean.Delorean))
 
-    def test_initialize_with_tzinfo_pytz(self):
-        aware_dt_pytz = datetime(2013, 1, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        do = delorean.Delorean(datetime=aware_dt_pytz)
+    def test_initialize_with_tzinfo_zoneinfo(self):
+        aware_dt_zoneinfo = datetime(2013, 1, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        do = delorean.Delorean(datetime=aware_dt_zoneinfo)
         self.assertTrue(isinstance(do, delorean.Delorean))
 
     def test_initialize_with_invalid_datetime(self):
         self.assertRaises(ValueError, delorean.Delorean, "2015-01-01")
 
-    def test_initialize_with_naive_datetime_with_pytz_timezone(self):
+    def test_initialize_with_naive_datetime_with_zoneinfo_timezone(self):
         dt = datetime(2015, 1, 1)
-        do = delorean.Delorean(dt, timezone=pytz.utc)
+        do = delorean.Delorean(dt, timezone=delorean.utc)
 
-        dt = pytz.utc.localize(dt)
+        dt = dt.replace(tzinfo=timezone.utc)
         self.assertEqual(do.datetime, dt)
-        self.assertEqual(do.timezone, pytz.utc)
+        self.assertEqual(do.timezone, delorean.utc)
 
     def test_initialize_with_naive_datetime_with_dateutil_timezone(self):
         dt = datetime(2015, 1, 1)
@@ -87,19 +86,19 @@ class DeloreanTests(unittest.TestCase):
             utcoffset.microseconds
             + (utcoffset.seconds + utcoffset.days * 24 * 3600) * 10**6
         ) / 10**6
-        tz = pytz.FixedOffset(total_seconds / 60)
-        dt = tz.localize(dt)
+        tz = timezone(timedelta(minutes=total_seconds / 60))
+        dt = dt.replace(tzinfo=tz)
         self.assertEqual(do.datetime, dt)
         self.assertEqual(do.timezone, tz)
 
     def test_initialize_with_naive_datetime_with_string_timezone(self):
         dt = datetime(2015, 1, 1)
         tz_str = "US/Pacific"
-        tz = pytz.timezone(tz_str)
+        tz = ZoneInfo(tz_str)
         do = delorean.Delorean(dt, timezone=tz_str)
-        tz = tz.localize(datetime(2015, 1, 1)).tzinfo
+        tz = datetime(2015, 1, 1).replace(tzinfo=tz).tzinfo
 
-        dt = tz.localize(dt)
+        dt = dt.replace(tzinfo=tz)
         self.assertEqual(do.datetime, dt)
         self.assertEqual(do.timezone, tz)
 
@@ -109,25 +108,25 @@ class DeloreanTests(unittest.TestCase):
         )
 
     def test_initialize_with_datetime_with_timezone(self):
-        dt = pytz.utc.localize(datetime(2015, 1, 1))
-        do = delorean.Delorean(dt, timezone=pytz.timezone("US/Pacific"))
+        dt = datetime(2015, 1, 1).replace(tzinfo=timezone.utc)
+        do = delorean.Delorean(dt, timezone=ZoneInfo("US/Pacific"))
 
         self.assertEqual(do.datetime, dt)
-        self.assertEqual(do.timezone, pytz.utc)
+        self.assertEqual(do.timezone, timezone.utc)
 
     def test_initialize_with_datetime_without_timezone(self):
-        dt = pytz.utc.localize(datetime(2015, 1, 1))
+        dt = datetime(2015, 1, 1).replace(tzinfo=timezone.utc)
         do = delorean.Delorean(dt)
 
         self.assertEqual(do.datetime, dt)
-        self.assertEqual(do.timezone, pytz.utc)
+        self.assertEqual(do.timezone, timezone.utc)
 
     @mock.patch("delorean.dates.datetime_timezone")
-    def test_initialize_without_datetime_with_pytz_timezone(
+    def test_initialize_without_datetime_with_zoneinfo_timezone(
         self, mock_datetime_timezone
     ):
-        tz = pytz.timezone("US/Pacific")
-        dt = tz.localize(datetime(2015, 1, 1))
+        tz = ZoneInfo("US/Pacific")
+        dt = datetime(2015, 1, 1).replace(tzinfo=tz)
         tz = dt.tzinfo
         mock_datetime_timezone.return_value = dt
 
@@ -148,8 +147,8 @@ class DeloreanTests(unittest.TestCase):
             + (utcoffset.seconds + utcoffset.days * 24 * 3600) * 10**6
         ) / 10**6
 
-        tz = pytz.FixedOffset(total_seconds / 60)
-        dt = tz.normalize(dt)
+        tz = timezone(timedelta(minutes=total_seconds / 60))
+        dt = dt.astimezone(tz)
         mock_datetime_timezone.return_value = dt
 
         do = delorean.Delorean(timezone=tz)
@@ -161,8 +160,8 @@ class DeloreanTests(unittest.TestCase):
         self, mock_datetime_timezone
     ):
         tz_str = "US/Pacific"
-        tz = pytz.timezone(tz_str)
-        dt = tz.localize(datetime(2015, 1, 1))
+        tz = ZoneInfo(tz_str)
+        dt = datetime(2015, 1, 1).replace(tzinfo=tz)
         tz = dt.tzinfo
         mock_datetime_timezone.return_value = dt
 
@@ -172,12 +171,12 @@ class DeloreanTests(unittest.TestCase):
 
     @mock.patch("delorean.dates.datetime_timezone")
     def test_initialize_without_datetime_without_timezone(self, mock_datetime_timezone):
-        dt = pytz.utc.localize(datetime(2015, 1, 1))
+        dt = datetime(2015, 1, 1).replace(tzinfo=timezone.utc)
         mock_datetime_timezone.return_value = dt
 
         do = delorean.Delorean()
         self.assertEqual(do.datetime, dt)
-        self.assertEqual(do.timezone, pytz.utc)
+        self.assertEqual(do.timezone, delorean.utc)
 
     def test_truncation_hour(self):
         self.do.truncate("hour")
@@ -186,25 +185,29 @@ class DeloreanTests(unittest.TestCase):
     def test_midnight(self):
         do = self.do.midnight
         self.assertIsInstance(do, delorean.Delorean)
-        self.assertEqual(do.datetime, datetime(2013, 1, 3, 0, 0, 0, tzinfo=pytz.utc))
+        self.assertEqual(
+            do.datetime, datetime(2013, 1, 3, 0, 0, 0, tzinfo=delorean.utc)
+        )
 
     def test_start_of_day(self):
         do = self.do.start_of_day
         self.assertIsInstance(do, delorean.Delorean)
-        self.assertEqual(do.datetime, datetime(2013, 1, 3, 0, 0, 0, 0, tzinfo=pytz.utc))
+        self.assertEqual(
+            do.datetime, datetime(2013, 1, 3, 0, 0, 0, 0, tzinfo=delorean.utc)
+        )
 
     def test_end_of_day(self):
         do = self.do.end_of_day
         self.assertIsInstance(do, delorean.Delorean)
         self.assertEqual(
-            do.datetime, datetime(2013, 1, 3, 23, 59, 59, 999999, tzinfo=pytz.utc)
+            do.datetime, datetime(2013, 1, 3, 23, 59, 59, 999999, tzinfo=delorean.utc)
         )
 
     def test_day_boundaries_are_chainable(self):
         do = self.do.last_month().end_of_day
         self.assertIsInstance(do, delorean.Delorean)
         self.assertEqual(
-            do.datetime, datetime(2012, 12, 3, 23, 59, 59, 999999, tzinfo=pytz.utc)
+            do.datetime, datetime(2012, 12, 3, 23, 59, 59, 999999, tzinfo=delorean.utc)
         )
         # Still a Delorean, so the chain can continue.
         self.assertIsInstance(do.shift("US/Eastern"), delorean.Delorean)
@@ -212,14 +215,14 @@ class DeloreanTests(unittest.TestCase):
     def test_start_of_month(self):
         do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
         self.assertEqual(
-            do.start_of_month.datetime, datetime(2015, 5, 1, tzinfo=pytz.utc)
+            do.start_of_month.datetime, datetime(2015, 5, 1, tzinfo=delorean.utc)
         )
 
     def test_end_of_month(self):
         do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
         self.assertEqual(
             do.end_of_month.datetime,
-            datetime(2015, 5, 31, 23, 59, 59, 999999, tzinfo=pytz.utc),
+            datetime(2015, 5, 31, 23, 59, 59, 999999, tzinfo=delorean.utc),
         )
 
     def test_end_of_month_short_month(self):
@@ -233,14 +236,14 @@ class DeloreanTests(unittest.TestCase):
     def test_start_of_year(self):
         do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
         self.assertEqual(
-            do.start_of_year.datetime, datetime(2015, 1, 1, tzinfo=pytz.utc)
+            do.start_of_year.datetime, datetime(2015, 1, 1, tzinfo=delorean.utc)
         )
 
     def test_end_of_year(self):
         do = delorean.Delorean(datetime(2015, 5, 15, 14, 30), timezone="UTC")
         self.assertEqual(
             do.end_of_year.datetime,
-            datetime(2015, 12, 31, 23, 59, 59, 999999, tzinfo=pytz.utc),
+            datetime(2015, 12, 31, 23, 59, 59, 999999, tzinfo=delorean.utc),
         )
 
     def test_last_day_of_previous_month(self):
@@ -306,7 +309,7 @@ class DeloreanTests(unittest.TestCase):
     def test_localize(self):
         dt = datetime.today()
         dt = delorean.localize(dt, "UTC")
-        self.assertEqual(dt.tzinfo, pytz.utc)
+        self.assertEqual(dt.tzinfo, delorean.utc)
 
     def test_failure_truncation(self):
         self.assertRaises(ValueError, self.do.truncate, "century")
@@ -329,7 +332,7 @@ class DeloreanTests(unittest.TestCase):
 
     def test_timezone(self):
         do_timezone = delorean.Delorean().timezone
-        self.assertEqual(pytz.utc, do_timezone)
+        self.assertEqual(delorean.utc, do_timezone)
 
     def test_datetime_timezone_default(self):
         do = delorean.Delorean()
@@ -346,18 +349,19 @@ class DeloreanTests(unittest.TestCase):
     def test_parse(self):
         with self.assertWarns(UnknownTimezoneWarning):
             do = delorean.parse("Thu Sep 25 10:36:28 BRST 2003")
-        dt1 = pytz.utc.localize(datetime(2003, 9, 25, 10, 36, 28))
+        dt1 = datetime(2003, 9, 25, 10, 36, 28).replace(tzinfo=timezone.utc)
         self.assertEqual(do.datetime, dt1)
 
     def test_parse_iso(self):
         do = delorean.parse("2017-05-02T05:38:49Z")
-        dt1 = pytz.utc.localize(datetime(2017, 5, 2, 5, 38, 49))
+        dt1 = datetime(2017, 5, 2, 5, 38, 49).replace(tzinfo=timezone.utc)
         self.assertEqual(do.datetime, dt1)
 
     def test_parse_default(self):
         do = delorean.parse("2016-07-01T11:00:00+02:00", dayfirst=False)
         dt1 = delorean.Delorean(
-            datetime=datetime(2016, 7, 1, 11, 0), timezone=pytz.FixedOffset(120)
+            datetime=datetime(2016, 7, 1, 11, 0),
+            timezone=timezone(timedelta(minutes=120)),
         )
         self.assertEqual(do.datetime, dt1.datetime)
 
@@ -369,7 +373,7 @@ class DeloreanTests(unittest.TestCase):
 
         self.assertEqual(
             do.datetime,
-            datetime(2015, 2, 4, 16, 33, 21, 247513, tzinfo=pytz.utc),
+            datetime(2015, 2, 4, 16, 33, 21, 247513, tzinfo=delorean.utc),
         )
 
     def test_parse_timezone_less_string_can_require_assumption(self):
@@ -387,7 +391,7 @@ class DeloreanTests(unittest.TestCase):
         self.assertIsInstance(do, delorean.Delorean)
         self.assertEqual(
             do.datetime,
-            datetime(2015, 2, 4, 16, 33, 21, 247513, tzinfo=pytz.utc),
+            datetime(2015, 2, 4, 16, 33, 21, 247513, tzinfo=delorean.utc),
         )
 
     def test_parse_with_assumed_non_utc_timezone(self):
@@ -395,20 +399,20 @@ class DeloreanTests(unittest.TestCase):
             "2015-02-04T16:33:21.247513",
             assume_timezone="America/Toronto",
         )
-        expected = pytz.timezone("America/Toronto").localize(
-            datetime(2015, 2, 4, 16, 33, 21, 247513)
+        expected = datetime(2015, 2, 4, 16, 33, 21, 247513).replace(
+            tzinfo=ZoneInfo("America/Toronto")
         )
 
         self.assertIsInstance(do, delorean.Delorean)
         self.assertEqual(do.datetime, expected)
 
     def test_parse_with_assumed_timezone_object(self):
-        timezone = pytz.timezone("America/Toronto")
+        timezone = ZoneInfo("America/Toronto")
         do = delorean.parse(
             "2015-02-04T16:33:21.247513",
             assume_timezone=timezone,
         )
-        expected = timezone.localize(datetime(2015, 2, 4, 16, 33, 21, 247513))
+        expected = datetime(2015, 2, 4, 16, 33, 21, 247513).replace(tzinfo=timezone)
 
         self.assertEqual(do.datetime, expected)
 
@@ -418,7 +422,7 @@ class DeloreanTests(unittest.TestCase):
             assume_timezone="US/Pacific",
         )
 
-        self.assertEqual(do.timezone, pytz.FixedOffset(-300))
+        self.assertEqual(do.timezone, timezone(timedelta(minutes=-300)))
 
     def test_parse_timezone_override_takes_precedence_over_assumption(self):
         do = delorean.parse(
@@ -426,8 +430,8 @@ class DeloreanTests(unittest.TestCase):
             timezone="US/Pacific",
             assume_timezone="UTC",
         )
-        expected = pytz.timezone("US/Pacific").localize(
-            datetime(2015, 2, 4, 16, 33, 21, 247513)
+        expected = datetime(2015, 2, 4, 16, 33, 21, 247513).replace(
+            tzinfo=ZoneInfo("US/Pacific")
         )
 
         self.assertEqual(do.datetime, expected)
@@ -438,8 +442,8 @@ class DeloreanTests(unittest.TestCase):
             timezone="US/Pacific",
             assume_timezone=None,
         )
-        expected = pytz.timezone("US/Pacific").localize(
-            datetime(2015, 2, 4, 16, 33, 21, 247513)
+        expected = datetime(2015, 2, 4, 16, 33, 21, 247513).replace(
+            tzinfo=ZoneInfo("US/Pacific")
         )
 
         self.assertEqual(do.datetime, expected)
@@ -447,7 +451,9 @@ class DeloreanTests(unittest.TestCase):
     def test_parse_does_not_apply_assumed_timezone_to_utc_designator(self):
         do = delorean.parse("2013-09-30T15:34:00.000Z", assume_timezone="US/Pacific")
 
-        self.assertEqual(do.datetime, pytz.utc.localize(datetime(2013, 9, 30, 15, 34)))
+        self.assertEqual(
+            do.datetime, datetime(2013, 9, 30, 15, 34).replace(tzinfo=timezone.utc)
+        )
 
     def test_parse_with_assumed_zoneinfo_timezone(self):
         tz = ZoneInfo("America/Toronto")
@@ -463,10 +469,10 @@ class DeloreanTests(unittest.TestCase):
 
         self.assertEqual(do.datetime.tzname(), "EST")
 
-    def test_parse_with_assumed_timezone_resolves_ambiguous_local_time(self):
+    def test_parse_with_assumed_timezone_takes_the_first_ambiguous_occurrence(self):
         do = delorean.parse("2013-11-03T01:30:00", assume_timezone="US/Eastern")
 
-        self.assertEqual(do.datetime.tzname(), "EST")
+        self.assertEqual(do.datetime.tzname(), "EDT")
 
     def test_parse_strict_error_is_a_value_error(self):
         with self.assertRaises(ValueError):
@@ -474,18 +480,18 @@ class DeloreanTests(unittest.TestCase):
 
     def test_parse_with_utc_year_fill(self):
         do = delorean.parse("Thu Sep 25 10:36:28")
-        dt1 = pytz.utc.localize(datetime(date.today().year, 9, 25, 10, 36, 28))
+        dt1 = datetime(date.today().year, 9, 25, 10, 36, 28, tzinfo=delorean.utc)
         self.assertEqual(do.datetime, dt1)
 
     def test_parse_with_assumed_timezone_year_fill(self):
         do = delorean.parse("Thu Sep 25 10:36:28", assume_timezone="UTC")
-        dt1 = pytz.utc.localize(datetime(date.today().year, 9, 25, 10, 36, 28))
+        dt1 = datetime(date.today().year, 9, 25, 10, 36, 28, tzinfo=delorean.utc)
         self.assertEqual(do.datetime, dt1)
         self.assertEqual(do.timezone.tzname(None), "UTC")
 
     def test_parse_with_fixed_offset_timezone(self):
-        tz = pytz.FixedOffset(-480)
-        dt = tz.localize(datetime(2015, 1, 1))
+        tz = timezone(timedelta(minutes=-480))
+        dt = datetime(2015, 1, 1).replace(tzinfo=tz)
         dt_str = dt.strftime("%Y-%m-%d %H:%M:%S %z")
 
         do = delorean.parse(dt_str)
@@ -494,12 +500,12 @@ class DeloreanTests(unittest.TestCase):
 
     @mock.patch("delorean.interface.get_localzone")
     def test_parse_with_tzlocal_timezone(self, mock_get_local_zone):
-        tz = pytz.timezone("US/Eastern")
+        tz = ZoneInfo("US/Eastern")
         mock_get_local_zone.return_value = tz
         dt = datetime(2015, 1, 1, tzinfo=tzlocal())
         dt_str = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
         dt = dt.replace(tzinfo=None)
-        dt = tz.localize(dt)
+        dt = dt.replace(tzinfo=tz)
         tz = dt.tzinfo
 
         do = delorean.parse(dt_str)
@@ -508,17 +514,17 @@ class DeloreanTests(unittest.TestCase):
 
     @mock.patch("delorean.interface.get_localzone")
     def test_parse_with_tzutc_timezone(self, mock_get_localzone):
-        mock_get_localzone.return_value = pytz.utc
-        dt = pytz.utc.localize(datetime(2015, 1, 1))
+        mock_get_localzone.return_value = delorean.utc
+        dt = datetime(2015, 1, 1).replace(tzinfo=timezone.utc)
         dt_str = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
 
         do = delorean.parse(dt_str)
         self.assertEqual(do.datetime, dt)
-        self.assertEqual(do.timezone, pytz.utc)
+        self.assertEqual(do.timezone, delorean.utc)
 
     def test_parse_with_timezone_parameter(self):
-        tz = pytz.timezone("US/Pacific")
-        dt = tz.localize(datetime(2015, 1, 1))
+        tz = ZoneInfo("US/Pacific")
+        dt = datetime(2015, 1, 1).replace(tzinfo=tz)
         tz = dt.tzinfo
         dt_str = dt.strftime("%Y-%m-%d %H:%M:%S")
 
@@ -527,8 +533,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(do.timezone, tz)
 
     def test_parse_with_overriding_timezone_parameter(self):
-        tz = pytz.timezone("US/Pacific")
-        dt = tz.localize(datetime(2015, 1, 1))
+        tz = ZoneInfo("US/Pacific")
+        dt = datetime(2015, 1, 1).replace(tzinfo=tz)
         tz = dt.tzinfo
         dt_str = dt.strftime("%Y-%m-%d %H:%M:%S -0500")
 
@@ -537,10 +543,10 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(do.timezone, tz)
 
     def test_move_namedday(self):
-        dt_next = datetime(2013, 1, 4, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_next_2 = datetime(2013, 1, 11, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 12, 28, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last_2 = datetime(2012, 12, 21, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 4, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_next_2 = datetime(2013, 1, 11, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 12, 28, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last_2 = datetime(2012, 12, 21, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = self.do.next_friday()
         d_obj_next_2 = self.do.next_friday(2)
@@ -553,8 +559,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last_2, d_obj_last_2.datetime)
 
     def test_move_namedday_function(self):
-        dt_next = datetime(2013, 1, 4, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 12, 28, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 4, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 12, 28, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_namedday(self.do.datetime, "next", "friday")
         d_obj_last = delorean.move_datetime_namedday(self.do.datetime, "last", "friday")
@@ -563,10 +569,10 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last, d_obj_last)
 
     def test_move_week(self):
-        dt_next = datetime(2013, 1, 10, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_next_2 = datetime(2013, 1, 17, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 12, 27, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last_2 = datetime(2012, 12, 20, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 10, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_next_2 = datetime(2013, 1, 17, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 12, 27, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last_2 = datetime(2012, 12, 20, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = self.do.next_week()
         d_obj_next_2 = self.do.next_week(2)
@@ -579,8 +585,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last_2, d_obj_last_2.datetime)
 
     def test_move_week_function(self):
-        dt_next = datetime(2013, 1, 10, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 12, 27, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 10, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 12, 27, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_week(self.do.datetime, "next", 1)
         d_obj_last = delorean.move_datetime_week(self.do.datetime, "last", 1)
@@ -589,10 +595,10 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last, d_obj_last)
 
     def test_move_month(self):
-        dt_next = datetime(2013, 2, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_next_2 = datetime(2013, 3, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 12, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last_2 = datetime(2012, 11, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 2, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_next_2 = datetime(2013, 3, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 12, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last_2 = datetime(2012, 11, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = self.do.next_month()
         d_obj_next_2 = self.do.next_month(2)
@@ -605,8 +611,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last_2, d_obj_last_2.datetime)
 
     def test_move_month_function(self):
-        dt_next = datetime(2013, 2, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 12, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 2, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 12, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_month(self.do.datetime, "next", 1)
         d_obj_last = delorean.move_datetime_month(self.do.datetime, "last", 1)
@@ -615,8 +621,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last, d_obj_last)
 
     def test_move_day_function(self):
-        dt_next = datetime(2013, 1, 4, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2013, 1, 2, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 4, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2013, 1, 2, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_day(self.do.datetime, "next", 1)
         d_obj_last = delorean.move_datetime_day(self.do.datetime, "last", 1)
@@ -625,10 +631,10 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last, d_obj_last)
 
     def test_move_year(self):
-        dt_next = datetime(2014, 1, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_next_2 = datetime(2015, 1, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 1, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last_2 = datetime(2011, 1, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2014, 1, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_next_2 = datetime(2015, 1, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 1, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last_2 = datetime(2011, 1, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = self.do.next_year()
         d_obj_next_2 = self.do.next_year(2)
@@ -641,8 +647,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last_2, d_obj_last_2.datetime)
 
     def test_move_year_function(self):
-        dt_next = datetime(2014, 1, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2012, 1, 3, 4, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2014, 1, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2012, 1, 3, 4, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_year(self.do.datetime, "next", 1)
         d_obj_last = delorean.move_datetime_year(self.do.datetime, "last", 1)
@@ -651,10 +657,10 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last, d_obj_last)
 
     def test_move_hour(self):
-        dt_next = datetime(2013, 1, 3, 5, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_next_2 = datetime(2013, 1, 3, 6, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2013, 1, 3, 3, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last_2 = datetime(2013, 1, 3, 2, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 3, 5, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_next_2 = datetime(2013, 1, 3, 6, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2013, 1, 3, 3, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last_2 = datetime(2013, 1, 3, 2, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = self.do.next_hour()
         d_obj_next_2 = self.do.next_hour(2)
@@ -667,8 +673,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last_2, d_obj_last_2.datetime)
 
     def test_move_hour_function(self):
-        dt_next = datetime(2013, 1, 3, 5, 31, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2013, 1, 3, 3, 31, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 3, 5, 31, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2013, 1, 3, 3, 31, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_hour(self.do.datetime, "next", 1)
         d_obj_last = delorean.move_datetime_hour(self.do.datetime, "last", 1)
@@ -677,10 +683,10 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last, d_obj_last)
 
     def test_move_minute(self):
-        dt_next = datetime(2013, 1, 3, 4, 32, 14, 148540, tzinfo=pytz.utc)
-        dt_next_2 = datetime(2013, 1, 3, 4, 33, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2013, 1, 3, 4, 30, 14, 148540, tzinfo=pytz.utc)
-        dt_last_2 = datetime(2013, 1, 3, 4, 29, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 3, 4, 32, 14, 148540, tzinfo=delorean.utc)
+        dt_next_2 = datetime(2013, 1, 3, 4, 33, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2013, 1, 3, 4, 30, 14, 148540, tzinfo=delorean.utc)
+        dt_last_2 = datetime(2013, 1, 3, 4, 29, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = self.do.next_minute()
         d_obj_next_2 = self.do.next_minute(2)
@@ -693,8 +699,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last_2, d_obj_last_2.datetime)
 
     def test_move_minute_function(self):
-        dt_next = datetime(2013, 1, 3, 4, 32, 14, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2013, 1, 3, 4, 30, 14, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 3, 4, 32, 14, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2013, 1, 3, 4, 30, 14, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_minute(self.do.datetime, "next", 1)
         d_obj_last = delorean.move_datetime_minute(self.do.datetime, "last", 1)
@@ -703,10 +709,10 @@ class DeloreanTests(unittest.TestCase):
         self.assertEqual(dt_last, d_obj_last)
 
     def test_move_second(self):
-        dt_next = datetime(2013, 1, 3, 4, 31, 15, 148540, tzinfo=pytz.utc)
-        dt_next_2 = datetime(2013, 1, 3, 4, 31, 16, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2013, 1, 3, 4, 31, 13, 148540, tzinfo=pytz.utc)
-        dt_last_2 = datetime(2013, 1, 3, 4, 31, 12, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 3, 4, 31, 15, 148540, tzinfo=delorean.utc)
+        dt_next_2 = datetime(2013, 1, 3, 4, 31, 16, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2013, 1, 3, 4, 31, 13, 148540, tzinfo=delorean.utc)
+        dt_last_2 = datetime(2013, 1, 3, 4, 31, 12, 148540, tzinfo=delorean.utc)
 
         d_obj_next = self.do.next_second()
         d_obj_next_2 = self.do.next_second(2)
@@ -721,16 +727,16 @@ class DeloreanTests(unittest.TestCase):
     def test_move_fractional_seconds(self):
         expected_datetimes = {
             ("next_second", 0.5): datetime(
-                2013, 1, 3, 4, 31, 14, 648540, tzinfo=pytz.utc
+                2013, 1, 3, 4, 31, 14, 648540, tzinfo=delorean.utc
             ),
             ("next_second", 1.5): datetime(
-                2013, 1, 3, 4, 31, 15, 648540, tzinfo=pytz.utc
+                2013, 1, 3, 4, 31, 15, 648540, tzinfo=delorean.utc
             ),
             ("last_second", 0.5): datetime(
-                2013, 1, 3, 4, 31, 13, 648540, tzinfo=pytz.utc
+                2013, 1, 3, 4, 31, 13, 648540, tzinfo=delorean.utc
             ),
             ("last_second", 1.5): datetime(
-                2013, 1, 3, 4, 31, 12, 648540, tzinfo=pytz.utc
+                2013, 1, 3, 4, 31, 12, 648540, tzinfo=delorean.utc
             ),
         }
 
@@ -750,8 +756,8 @@ class DeloreanTests(unittest.TestCase):
                         shift(0.5)
 
     def test_move_second_function(self):
-        dt_next = datetime(2013, 1, 3, 4, 31, 15, 148540, tzinfo=pytz.utc)
-        dt_last = datetime(2013, 1, 3, 4, 31, 13, 148540, tzinfo=pytz.utc)
+        dt_next = datetime(2013, 1, 3, 4, 31, 15, 148540, tzinfo=delorean.utc)
+        dt_last = datetime(2013, 1, 3, 4, 31, 13, 148540, tzinfo=delorean.utc)
 
         d_obj_next = delorean.move_datetime_second(self.do.datetime, "next", 1)
         d_obj_last = delorean.move_datetime_second(self.do.datetime, "last", 1)
@@ -806,23 +812,23 @@ class DeloreanTests(unittest.TestCase):
     def test_delorean_with_datetime(self):
         dt = naive_utcnow()
         d = delorean.Delorean(datetime=dt, timezone=UTC)
-        dt = pytz.utc.localize(dt)
+        dt = dt.replace(tzinfo=timezone.utc)
         self.assertEqual(dt, d._dt)
-        self.assertEqual(pytz.utc, d.timezone)
+        self.assertEqual(delorean.utc, d.timezone)
 
     def test_delorean_with_timezone(self):
         dt = naive_utcnow()
         d = delorean.Delorean(datetime=dt, timezone=UTC)
         d = d.shift("US/Eastern")
-        dt = pytz.utc.localize(dt).astimezone(est)
-        dt = est.normalize(dt)
+        dt = dt.replace(tzinfo=timezone.utc).astimezone(est)
+        dt = dt.astimezone(est)
         self.assertEqual(dt, d.datetime)
         self.assertEqual(est, d.timezone)
 
     def test_delorean_with_only_timezone(self):
         dt = naive_utcnow()
-        dt = pytz.utc.localize(dt)
-        dt = est.normalize(dt)
+        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.astimezone(est)
         dt = dt.replace(second=0, microsecond=0)
         d = delorean.Delorean(timezone="US/Eastern")
         d.truncate("minute")
@@ -844,8 +850,8 @@ class DeloreanTests(unittest.TestCase):
         self.assertFalse(hasattr(self.do, "next_bogus"))
 
     def test_shift_across_dst_keeps_wall_clock(self):
-        eastern = pytz.timezone("US/Eastern")
-        do = delorean.Delorean(eastern.localize(datetime(2013, 3, 9, 7, 0)))
+        eastern = ZoneInfo("US/Eastern")
+        do = delorean.Delorean(datetime(2013, 3, 9, 7, 0).replace(tzinfo=eastern))
 
         shifted = do.next_day().datetime
         self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-03-10 07:00")
@@ -854,30 +860,30 @@ class DeloreanTests(unittest.TestCase):
     def test_shift_into_nonexistent_local_time_resolves_to_standard(self):
         # Eastern clocks jump 02:00 EST -> 03:00 EDT on 2013-03-10, so 02:30
         # has no local reading at all that day.
-        eastern = pytz.timezone("US/Eastern")
-        do = delorean.Delorean(eastern.localize(datetime(2013, 3, 9, 2, 30)))
+        eastern = ZoneInfo("US/Eastern")
+        do = delorean.Delorean(datetime(2013, 3, 9, 2, 30).replace(tzinfo=eastern))
 
         shifted = do.next_day().datetime
         self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-03-10 02:30")
         self.assertEqual(shifted.tzname(), "EST")
-        self.assertEqual(shifted.astimezone(pytz.utc).strftime("%H:%M"), "07:30")
+        self.assertEqual(shifted.astimezone(delorean.utc).strftime("%H:%M"), "07:30")
 
-    def test_shift_into_ambiguous_local_time_resolves_to_standard(self):
+    def test_shift_into_ambiguous_local_time_takes_the_first_occurrence(self):
         # 01:30 happens twice on 2013-11-03, first as EDT and then as EST.
-        eastern = pytz.timezone("US/Eastern")
-        do = delorean.Delorean(eastern.localize(datetime(2013, 11, 2, 1, 30)))
+        eastern = ZoneInfo("US/Eastern")
+        do = delorean.Delorean(datetime(2013, 11, 2, 1, 30).replace(tzinfo=eastern))
 
         shifted = do.next_day().datetime
         self.assertEqual(shifted.strftime("%Y-%m-%d %H:%M"), "2013-11-03 01:30")
-        self.assertEqual(shifted.tzname(), "EST")
+        self.assertEqual(shifted.tzname(), "EDT")
 
     def test_localize_nonexistent_local_time_resolves_to_standard(self):
         dt = delorean.localize(datetime(2013, 3, 10, 2, 30), "US/Eastern")
         self.assertEqual(dt.tzname(), "EST")
 
-    def test_localize_ambiguous_local_time_resolves_to_standard(self):
+    def test_localize_ambiguous_local_time_takes_the_first_occurrence(self):
         dt = delorean.localize(datetime(2013, 11, 3, 1, 30), "US/Eastern")
-        self.assertEqual(dt.tzname(), "EST")
+        self.assertEqual(dt.tzname(), "EDT")
 
     def test_localize_with_zoneinfo_timezone(self):
         tz = ZoneInfo("US/Eastern")
@@ -887,7 +893,9 @@ class DeloreanTests(unittest.TestCase):
 
     def test_normalize_with_zoneinfo_timezone(self):
         tz = ZoneInfo("US/Eastern")
-        dt = delorean.normalize(pytz.utc.localize(datetime(2013, 1, 1, 12)), tz)
+        dt = delorean.normalize(
+            datetime(2013, 1, 1, 12).replace(tzinfo=timezone.utc), tz
+        )
 
         self.assertEqual(dt, datetime(2013, 1, 1, 7, tzinfo=tz))
 
@@ -906,12 +914,12 @@ class DeloreanTests(unittest.TestCase):
 
     def test_localize_datetime(self):
         dt = naive_utcnow()
-        tz = pytz.timezone("US/Pacific")
-        dt = tz.localize(dt)
+        tz = ZoneInfo("US/Pacific")
+        dt = dt.replace(tzinfo=tz)
         d = delorean.Delorean(dt)
         d2 = d.shift("US/Pacific")
 
-        self.assertEqual(d.timezone.tzname(None), "US/Pacific")
+        self.assertEqual(str(d.timezone), "US/Pacific")
         self.assertEqual(d.datetime, dt)
         self.assertEqual(d.datetime, d2.datetime)
 
@@ -992,7 +1000,7 @@ class DeloreanTests(unittest.TestCase):
 
         self.assertEqual(d1, d4)
 
-    def test_repr_pytz_timezone(self):
+    def test_repr_named_timezone(self):
         import datetime
 
         from delorean import Delorean
@@ -1010,8 +1018,8 @@ class DeloreanTests(unittest.TestCase):
         # Resolved by the eval(repr(...)) below, so static analysis sees no use.
         from delorean import Delorean  # noqa: F401
 
-        tz = pytz.timezone("US/Pacific")
-        dt = tz.localize(datetime.datetime(2015, 1, 1))
+        tz = ZoneInfo("US/Pacific")
+        dt = datetime.datetime(2015, 1, 1).replace(tzinfo=tz)
         dt_str = dt.strftime("%Y-%m-%d %H:%M:%S %z")
 
         d1 = delorean.parse(dt_str)
@@ -1135,6 +1143,103 @@ class DeloreanTests(unittest.TestCase):
         # Test the datetime
         eight_hours_late = dt + timedelta(hours=8)
         self.assertEqual(do.replace(hour=8).datetime, eight_hours_late)
+
+
+class StdlibTimezoneTests(unittest.TestCase):
+    """The 2.0 timezone surface: standard library types, no pytz anywhere."""
+
+    def test_utc_constant_is_exported(self):
+        self.assertEqual(delorean.utc, ZoneInfo("UTC"))
+
+    def test_timezone_helper_returns_a_named_zone(self):
+        self.assertEqual(delorean.timezone("US/Eastern"), ZoneInfo("US/Eastern"))
+
+    def test_timezone_helper_understands_an_offset_string(self):
+        self.assertEqual(
+            delorean.timezone("UTC-08:00").utcoffset(None), timedelta(hours=-8)
+        )
+
+    def test_timezone_helper_understands_a_positive_offset_string(self):
+        self.assertEqual(
+            delorean.timezone("UTC+05:30").utcoffset(None),
+            timedelta(hours=5, minutes=30),
+        )
+
+    def test_timezone_helper_passes_a_tzinfo_through(self):
+        tz = ZoneInfo("US/Eastern")
+
+        self.assertIs(delorean.timezone(tz), tz)
+
+    def test_timezone_helper_rejects_an_unknown_name(self):
+        with self.assertRaises(delorean.DeloreanInvalidTimezone):
+            delorean.timezone("Not/AZone")
+
+    def test_error_base_class_is_exported(self):
+        self.assertTrue(issubclass(delorean.DeloreanError, ValueError))
+
+    def test_named_zone_is_a_zoneinfo(self):
+        do = delorean.Delorean(datetime(2013, 1, 15, 12), timezone="US/Eastern")
+
+        self.assertIsInstance(do.timezone, ZoneInfo)
+
+    def test_parsed_offset_is_a_stdlib_timezone(self):
+        do = delorean.parse("2015-01-01 00:01:02 -0800")
+
+        self.assertIsInstance(do.timezone, timezone)
+
+    def test_no_third_party_timezone_types_escape(self):
+        values = [
+            delorean.Delorean(datetime(2013, 1, 15, 12), timezone="US/Eastern"),
+            delorean.parse("2015-01-01 00:01:02 -0800"),
+            delorean.parse("2013-09-30T15:34:00.000Z"),
+            delorean.utcnow(),
+        ]
+
+        for do in values:
+            with self.subTest(value=repr(do)):
+                self.assertIn(type(do.timezone).__module__, ("zoneinfo", "datetime"))
+
+    def test_constructor_accepts_an_offset_string(self):
+        do = delorean.Delorean(datetime(2015, 1, 1), timezone="UTC-08:00")
+
+        self.assertEqual(do.datetime.utcoffset(), timedelta(hours=-8))
+
+    def test_repr_prints_an_offset_as_a_string(self):
+        do = delorean.parse("2015-01-01 00:01:02 -0800")
+
+        self.assertIn("timezone='UTC-08:00'", repr(do))
+
+    def test_repr_prints_a_named_zone_as_its_key(self):
+        do = delorean.Delorean(datetime(2013, 1, 15, 12), timezone="US/Eastern")
+
+        self.assertIn("timezone='US/Eastern'", repr(do))
+
+    def test_unknown_zone_in_constructor_raises_delorean_error(self):
+        with self.assertRaises(delorean.DeloreanInvalidTimezone):
+            delorean.Delorean(datetime(2013, 1, 15, 12), timezone="Not/AZone")
+
+    def test_unknown_assumed_zone_in_parse_raises_delorean_error(self):
+        with self.assertRaises(delorean.DeloreanInvalidTimezone):
+            delorean.parse("2015-02-04T16:33:21", assume_timezone="Not/AZone")
+
+    def test_ambiguous_local_time_takes_the_first_occurrence(self):
+        # zoneinfo's fold=0 default: 01:30 resolves to the daylight side.
+        do = delorean.Delorean(datetime(2013, 11, 3, 1, 30), timezone="US/Eastern")
+
+        self.assertEqual(do.datetime.tzname(), "EDT")
+        self.assertEqual(
+            do.datetime.astimezone(timezone.utc),
+            datetime(2013, 11, 3, 5, 30, tzinfo=timezone.utc),
+        )
+
+    def test_nonexistent_local_time_still_takes_standard_time(self):
+        do = delorean.Delorean(datetime(2013, 3, 10, 2, 30), timezone="US/Eastern")
+
+        self.assertEqual(do.datetime.tzname(), "EST")
+        self.assertEqual(
+            do.datetime.astimezone(timezone.utc),
+            datetime(2013, 3, 10, 7, 30, tzinfo=timezone.utc),
+        )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -188,13 +188,12 @@ wheels = [
 
 [[package]]
 name = "delorean"
-version = "1.0.1"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },
     { name = "humanize" },
     { name = "python-dateutil" },
-    { name = "pytz" },
     { name = "tzlocal" },
 ]
 
@@ -215,7 +214,6 @@ requires-dist = [
     { name = "babel", specifier = ">=2.10.3" },
     { name = "humanize", specifier = ">=4.2.2" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
-    { name = "pytz", specifier = ">=2022.1" },
     { name = "tzlocal", specifier = ">=4.2" },
 ]
 
@@ -518,15 +516,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
     { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2026.3.post1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR replaces Delorean’s `pytz`-based timezone handling with Python’s standard library `zoneinfo` and updates the public API to use stdlib timezone objects throughout. It also raises the minimum supported Python version to 3.10 and updates documentation and tests to reflect the new behavior.

## Changes Made
- Reworked timezone creation and normalization to use `zoneinfo.ZoneInfo` and `datetime.timezone` instead of `pytz`.
- Added a new `delorean/timezones.py` module to centralize timezone construction and related helpers.
- Updated `Delorean`, `parse()`, and related date utilities to operate on stdlib timezone objects and new timezone error semantics.
- Changed handling of ambiguous local times to follow stdlib `fold=0` behavior.
- Updated `repr()`/round-tripping behavior for fixed-offset timezones to use human-readable UTC offset strings.
- Made `localize()` reject already-aware datetimes instead of silently replacing their timezone.
- Removed `pytz` from the dependency model and updated package imports accordingly.
- Raised the minimum supported Python version to 3.10.
- Updated README and docs to describe the new timezone model and migration guidance.
- Expanded/adjusted test coverage and task notes for the zoneinfo migration.

## Files Modified
- `delorean/__init__.py` — updated public exports for the new timezone API.
- `delorean/dates.py` — core datetime/timezone behavior rewritten for stdlib timezone types.
- `delorean/interface.py` — parsing and timezone integration updated for new timezone handling.
- `delorean/timezones.py` — new helper module for timezone construction and conversion.
- `delorean/exceptions.py` — updated exception usage for invalid timezone handling.
- `docs/index.rst` — documentation updates for the new version and timezone behavior.
- `docs/quickstart.rst` — examples updated to use `zoneinfo` and `datetime.timezone`.
- `README.rst` — refreshed top-level usage/documentation references.
- `TASKS.md` — migration notes and task status updates.
- Additional test files — updated/added coverage for timezone semantics and edge cases.

## Important Notes
- This is a breaking change for consumers that depend on `pytz`-specific behavior or types, including comparisons against `pytz.utc`, `pytz.FixedOffset`, or catching `pytz.UnknownTimeZoneError`.
- Ambiguous DST fall-back times may now resolve differently than before due to `zoneinfo`/`fold` semantics.
- `localize()` now fails for already-aware datetimes, which may affect callers that previously relied on timezone replacement.
- Minimum Python version is now **3.10**.
- Testing: the migration was validated by expanded behavior tests covering offsets, zone names, ambiguous times, and round-tripping behavior.

Fixes #79