### PR TITLE
Add Read the Docs configuration for documentation builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+  jobs:
+    # docs/conf.py reads the version from the installed package metadata, so the
+    # project itself has to be installed, not just the documentation tools.
+    install:
+      - pip install uv
+      - uv sync --frozen --group docs
+    build:
+      html:
+        - uv run sphinx-build -b html -W docs $READTHEDOCS_OUTPUT/html
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
## Summary
This change adds a Read the Docs configuration so the project documentation can be built in a managed RTD environment. It ensures the application package is installed as part of the docs build, which is required for `docs/conf.py` to read version metadata correctly.

## Changes Made
- Added a new `.readthedocs.yaml` file to configure Read the Docs builds
- Set the build environment to Ubuntu 24.04 with Python 3.13
- Configured docs dependency installation via `uv sync --frozen --group docs`
- Ensured the project is installed before documentation is built
- Defined the Sphinx HTML build command with warnings treated as errors
- Pointed Read the Docs to use `docs/conf.py` as the Sphinx configuration

## Files Modified
- `.readthedocs.yaml` — new Read the Docs build configuration for documentation generation

## Important Notes
- This change is documentation-only and does not affect runtime application behavior.
- The build uses `uv` and requires the docs dependency group to be kept in sync.
- No tests were added or run as part of this change; validation is primarily through the Read the Docs build process.