### PR TITLE
Replace deprecated GitHub ribbons with inline SVG links

### DIFF
--- a/docs/_themes/kr/layout.html
+++ b/docs/_themes/kr/layout.html
@@ -11,23 +11,9 @@
     <div class="footer">
       &copy; Copyright {{ copyright }}.
     </div>
-    <a href="https://github.com/myusuf3/delorean" class="github">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" />
+    <a href="https://github.com/myusuf3/delorean" class="github-link" aria-label="View delorean on GitHub" title="View on GitHub">
+      <svg viewBox="0 0 16 16" width="24" height="24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
     </a>
-
-<script type="text/javascript">
-  var _gauges = _gauges || [];
-  (function() {
-    var t   = document.createElement('script');
-    t.type  = 'text/javascript';
-    t.async = true;
-    t.id    = 'gauges-tracker';
-    t.setAttribute('data-site-id', '50f10bd6613f5d3e2c00000e');
-    t.src = '//secure.gaug.es/track.js';
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(t, s);
-  })();
-</script>
 
 
 

--- a/docs/_themes/kr/static/flasky.css_t
+++ b/docs/_themes/kr/static/flasky.css_t
@@ -435,7 +435,7 @@ a:hover tt {
         width: auto;
     }
 
-    .github {
+    .github-link {
         display: none;
     }
 
@@ -526,7 +526,7 @@ a:hover tt {
         width: auto;
     }
 
-    .github {
+    .github-link {
         display: none;
     }
 }
@@ -535,4 +535,31 @@ a:hover tt {
 
 .revsys-inline {
     display: none!important;
+}
+/* GitHub link, rendered as an inline SVG so the page makes no external
+   requests. Replaces the retired s3.amazonaws.com fork ribbon. */
+
+.github-link {
+    position: fixed;
+    /* Clears the Read the Docs addons bar, which pins itself top right. */
+    top: 52px;
+    right: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px;
+    border-radius: 6px;
+    color: #999;
+    line-height: 0;
+    transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.github-link:hover,
+.github-link:focus-visible {
+    color: #222;
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.github-link svg {
+    display: block;
 }

--- a/docs/_themes/kr_small/layout.html
+++ b/docs/_themes/kr_small/layout.html
@@ -14,8 +14,9 @@
 {% block relbar1 %}{% endblock %}
 {% block relbar2 %}
   {% if theme_github_fork %}
-    <a href="http://github.com/{{ theme_github_fork }}"><img style="position: fixed; top: 0; right: 0; border: 0;"
-    src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/{{ theme_github_fork }}" class="github-link" aria-label="View this project on GitHub" title="View on GitHub">
+      <svg viewBox="0 0 16 16" width="24" height="24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+    </a>
   {% endif %}
 {% endblock %}
 {% block sidebar1 %}{% endblock %}


### PR DESCRIPTION
## Summary
This change updates the docs themes to use a lightweight inline SVG GitHub link instead of the old hosted “Fork me on GitHub” ribbon image. It also removes the external tracking script from the main theme layout and adds styling to position and display the new GitHub link consistently.

## Changes Made
- Replaced the legacy GitHub ribbon image in `docs/_themes/kr/layout.html` with an inline SVG GitHub link.
- Removed the external Gauges tracking script from `docs/_themes/kr/layout.html`.
- Updated `docs/_themes/kr/static/flasky.css_t` to style the new `.github-link` element.
- Added hover/focus styling for the GitHub link to improve usability and accessibility.
- Updated the small theme layout in `docs/_themes/kr_small/layout.html` to use the same inline SVG GitHub link when `theme_github_fork` is enabled.
- Switched the GitHub URL in the small theme to HTTPS.

## Files Modified
- `docs/_themes/kr/layout.html` — Replaced ribbon markup with inline SVG GitHub link; removed external analytics script.
- `docs/_themes/kr/static/flasky.css_t` — Added styling for the new GitHub link and updated responsive rules.
- `docs/_themes/kr_small/layout.html` — Replaced the ribbon with the new inline SVG GitHub link for forked projects.

## Important Notes
- The old GitHub ribbon asset hosted on `s3.amazonaws.com` is no longer used, so the docs page now avoids that external dependency.
- The removal of the Gauges script eliminates that third-party tracking integration from the theme layout.
- I did not see any tests included in the diff; this appears to be a documentation/theme-only change, so visual verification in the rendered docs would be the primary validation.